### PR TITLE
Release 0.8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,9 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      CODESIGN_CERTIFICATE: ${{ secrets.CODESIGN_CERTIFICATE }}
+      CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+      CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
     steps:
       - name: enable windows longpaths
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `banshee watch --waybar` emits one Waybar custom-module object per line, so
+  the microphone state can sit in a Wayland bar with no tray and no GUI. `text`
+  shows, `alt` selects a `format-icons` entry, and `class` is the CSS hook.
+  Readiness is left out on purpose: the daemon answers it once at connect and
+  never pushes it, so a bar showing it would go stale. Set `restart-interval`
+  in Waybar, since the command exits when the daemon stops.
+
 - **Model downloads resume.** Each file streams to `<name>.part` and is renamed
   into place only when complete, so an interrupted download is never mistaken
   for a model and the next `banshee setup` continues from where it stopped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to Banshee are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-08-21
+
+**Upgrading from 0.7.0 or earlier asks for macOS permissions once more.** This is
+the first signed release. Earlier builds carried an ad-hoc signature, which
+changes on every build, so macOS could not tell one version from the next and
+dropped the grants each time. Releases are now signed with a stable certificate,
+so grant Accessibility, Input Monitoring and Microphone one final time and no
+later upgrade will ask again.
 
 ### Added
 
@@ -381,6 +388,7 @@ First public release. macOS only for now; Windows and Linux support is planned.
   reported back through `banshee status`.
 
 [Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.7.0...HEAD
+[0.8.0]: https://github.com/yamanahlawat/banshee/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/yamanahlawat/banshee/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/yamanahlawat/banshee/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/yamanahlawat/banshee/compare/v0.5.0...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "banshee"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dirs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bansheed", "banshee-common"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Yaman Ahlawat"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The CLI commands all talk to the running daemon over its socket:
 | `banshee status --json`         | The same as machine-readable state and blockers            |
 | `banshee devices`               | List the microphones, and mark the one in use              |
 | `banshee watch`                 | Follow what the daemon is doing, one line per change       |
+| `banshee watch --waybar`        | The same, as Waybar custom-module JSON                     |
 | `banshee voices`                | List the speech voices on disk, and mark the one in use    |
 | `banshee config set <key> <value>` | Change one setting in `config.toml`                     |
 | `banshee serve`                 | Run the daemon in the foreground                           |
@@ -346,6 +347,40 @@ The command runs until the daemon stops, and then exits non-zero, so a
 supervisor can restart it. For a single answer rather than a stream, ask
 `banshee status`: a reader that stops early only ends `banshee watch` at the
 next change, which on a quiet daemon may be a long wait.
+
+### Showing the state in a Waybar module
+
+`banshee watch --waybar` emits one Waybar custom-module object per line:
+
+```json
+{"text":"recording","alt":"recording","class":"recording","tooltip":"Banshee is recording. Microphone: Blue Yeti"}
+```
+
+`text` shows, `alt` picks a `format-icons` entry, and `class` is the CSS hook.
+Put this in your Waybar config:
+
+```jsonc
+"custom/banshee": {
+    "exec": "banshee watch --waybar",
+    "return-type": "json",
+    "restart-interval": 5,
+    "format": "{icon}",
+    "format-icons": { "idle": "mic", "recording": "REC", "speaking": "spk" }
+}
+```
+
+and style it in your own CSS:
+
+```css
+#custom-banshee.recording { color: #e06c75; }
+#custom-banshee.speaking  { color: #61afef; }
+```
+
+`restart-interval` matters: the command exits when the daemon stops, and that
+is how the module reconnects once it comes back. Readiness is deliberately not
+in the module. The daemon answers it when you connect and never pushes it
+again, so a bar that showed it would be right once and wrong from then on. Ask
+`banshee status` for that.
 
 The same channel is open to any client over `banshee.subscribe`, which answers
 with everything `banshee.status` reports and then sends

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 anyhow = "1.0.103"
 arboard = "3.6.1"
 audioadapter-buffers = "3.0.0"
-banshee-common = { version = "0.7.0", path = "../banshee-common" }
+banshee-common = { version = "0.8.0", path = "../banshee-common" }
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.17.3"
 crossbeam-channel = "0.5.16"

--- a/bansheed/src/args.rs
+++ b/bansheed/src/args.rs
@@ -24,7 +24,11 @@ pub enum CommandType {
     /// List the microphones Banshee can record from
     Devices,
     /// Follow what the daemon is doing, one line per change
-    Watch,
+    Watch {
+        /// Emit Waybar custom-module JSON instead of one word
+        #[clap(long)]
+        waybar: bool,
+    },
     /// List the text-to-speech voices that are on disk
     Voices,
     /// Change a setting in config.toml

--- a/bansheed/src/main.rs
+++ b/bansheed/src/main.rs
@@ -150,6 +150,24 @@ fn decoded<T: serde::de::DeserializeOwned>(reply: &serde_json::Value, key: &str)
     }
 }
 
+// One object per line, as Waybar requires. The same word lands in three keys
+// because Waybar splits them: `text` shows, `alt` picks a format-icon, `class`
+// picks CSS. Readiness is left out: blockers are answered once and never
+// pushed, so a bar would show them stale.
+fn waybar_line(word: &str, device: Option<&str>) -> String {
+    let tooltip = match device {
+        Some(device) => format!("Banshee is {word}. Microphone: {device}"),
+        None => format!("Banshee is {word}"),
+    };
+    serde_json::json!({
+        "text": word,
+        "alt": word,
+        "class": word,
+        "tooltip": tooltip,
+    })
+    .to_string()
+}
+
 /// One word for the two booleans a subscriber is sent. The microphone outranks
 /// the speaker: it is what the user is waiting on.
 fn state_word(state: &serde_json::Value) -> &'static str {
@@ -363,7 +381,7 @@ async fn main() -> Result<(), BansheeError> {
             println!();
             println!("Speak with one by: banshee config set tts.voice \"<name>\"");
         }
-        CommandType::Watch => {
+        CommandType::Watch { waybar } => {
             let (mut state, mut changes) =
                 match utils::Subscription::open(&[banshee_common::EVENT_STATE]).await {
                     Ok(subscription) => subscription,
@@ -373,6 +391,11 @@ async fn main() -> Result<(), BansheeError> {
                     }
                     Err(error) => fail(&error),
                 };
+            // Only the opening reply carries it; a change carries the live fields
+            let device = state
+                .get("audio_device")
+                .and_then(|name| name.as_str())
+                .map(str::to_string);
             let mut shown = "";
             loop {
                 let word = state_word(&state);
@@ -380,9 +403,14 @@ async fn main() -> Result<(), BansheeError> {
                 // move without changing the one word they are printed as
                 if word != shown {
                     shown = word;
+                    let line = if waybar {
+                        waybar_line(word, device.as_deref())
+                    } else {
+                        word.to_string()
+                    };
                     // `banshee watch | head` closes the pipe. That is the reader
                     // having seen enough, not this command failing
-                    if writeln!(std::io::stdout(), "{word}").is_err() {
+                    if writeln!(std::io::stdout(), "{line}").is_err() {
                         return Ok(());
                     }
                 }
@@ -599,8 +627,52 @@ async fn main() -> Result<(), BansheeError> {
 
 #[cfg(test)]
 mod tests {
-    use super::state_word;
+    use super::{state_word, waybar_line};
     use banshee_common::InputDevice;
+
+    #[test]
+    fn a_waybar_line_is_one_parseable_object() {
+        let line = waybar_line("recording", Some("Blue Yeti"));
+        assert!(
+            !line.contains('\n'),
+            "Waybar reads one object per line: {line}"
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&line).expect("valid JSON");
+        assert_eq!(parsed["text"], "recording");
+        assert_eq!(parsed["alt"], "recording", "format-icons keys on alt");
+        assert_eq!(parsed["class"], "recording", "CSS keys on class");
+        assert!(
+            parsed["tooltip"].as_str().unwrap().contains("Blue Yeti"),
+            "{parsed}"
+        );
+    }
+
+    // A device name is whatever the hardware calls itself, so it has to be
+    // escaped rather than pasted into the line
+    #[test]
+    fn a_quote_in_the_device_name_does_not_break_the_line() {
+        let line = waybar_line("idle", Some("Bob\"s \\ Mic"));
+        let parsed: serde_json::Value = serde_json::from_str(&line).expect("valid JSON");
+        assert!(
+            parsed["tooltip"]
+                .as_str()
+                .unwrap()
+                .contains("Bob\"s \\ Mic")
+        );
+    }
+
+    #[test]
+    fn an_unknown_device_is_left_out_rather_than_named_empty() {
+        let line = waybar_line("idle", None);
+        let parsed: serde_json::Value = serde_json::from_str(&line).expect("valid JSON");
+        let tooltip = parsed["tooltip"].as_str().unwrap();
+        assert!(
+            !tooltip.contains("Microphone"),
+            "no device means none is named: {tooltip}"
+        );
+        assert!(tooltip.contains("idle"), "{tooltip}");
+    }
 
     #[test]
     fn the_microphone_outranks_the_speaker_in_one_word() {

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,9 +12,10 @@ installers = ["shell", "homebrew"]
 # Dropped: x86_64-apple-darwin (ort ships no Intel-mac prebuilt) and Windows (UDS
 # unported). aarch64 Linux builds natively on ubuntu-*-arm. Source install covers
 # the rest.
-targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
 # Homebrew formula is published to this tap repo (must exist on GitHub).
 tap = "yamanahlawat/homebrew-banshee"
+# Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
@@ -22,6 +23,11 @@ install-path = "CARGO_HOME"
 hosting = "github"
 # Whether to install an updater program
 install-updater = false
+# TCC keys Accessibility and Input Monitoring to the code signature, and an
+# ad-hoc one changes every build, so users would re-grant on every upgrade.
+# The certificate is self-signed and lives in repo secrets; no Apple membership
+# is involved. Note `dist init` rewrites the comments in this file.
+macos-sign = true
 
 # Pin Linux runners to 24.04; the ORT prebuilt needs glibc 2.38+.
 [dist.github-custom-runners]


### PR DESCRIPTION
Breaking: `banshee doctor`, `banshee readiness`, `banshee.readiness` and `status.recording_error` are gone; `banshee.configure` takes a new params shape.

First signed release, so upgrading asks for macOS permissions once more. Full notes in CHANGELOG.md.