### PR TITLE
feat: banshee connect wires a coding agent after showing the change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`banshee connect` wires up your coding agent.** `banshee connect antigravity`,
+  `claude`, `codex`, `cursor`, `opencode` or `pi` detects the tool, shows the exact
+  change to its config, and writes it only after you say yes. Claude Code gets the MCP
+  server and a stop hook that makes each turn end with a spoken status; the others get
+  the MCP server entry, and Pi its native extension. `banshee connect` alone lists what
+  is installed and what is connected. A server already registered by its bare name
+  counts as connected when `PATH` resolves it to the same shim.
+
 ### Fixed
 
 - **A microphone that disappears no longer kills dictation.** Unplug a Bluetooth

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "dirs",
  "enigo",
  "hound",
+ "json5",
  "misaki-rs",
  "ndarray",
  "ort",
@@ -310,6 +311,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "similar",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
@@ -1863,6 +1865,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,6 +2794,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,6 +3593,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3615,6 +3671,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -4236,6 +4298,12 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The CLI commands all talk to the running daemon over its socket:
 | `banshee watch --waybar`        | The same, as Waybar custom-module JSON                     |
 | `banshee voices`                | List the speech voices on disk, and mark the one in use    |
 | `banshee config set <key> <value>` | Change one setting in `config.toml`                     |
+| `banshee connect [agent]`       | Connect a coding agent, after showing the change           |
 | `banshee serve`                 | Run the daemon in the foreground                           |
 | `banshee tray`                  | Show the menu bar icon, now and at every login (macOS)     |
 | `banshee tray --uninstall`      | Stop the menu bar icon and remove its launch agent         |
@@ -190,11 +191,25 @@ The CLI commands all talk to the running daemon over its socket:
 | `banshee history`               | List all saved transcriptions                              |
 | `banshee clear-history`         | Clear the saved transcriptions                             |
 
-## Connect your coding agent (MCP)
+## Connect your coding agent
 
-`banshee-mcp-shim` is an MCP stdio server that bridges your coding agent to the
-running daemon. This is what turns Banshee into a voice for the agent. It
-exposes three tools:
+```bash
+banshee connect            # which agents are installed, and which are connected
+banshee connect antigravity # Antigravity IDE, agy CLI and SDK: the MCP server in ~/.gemini/config/mcp_config.json
+banshee connect claude      # Claude Code: the MCP server and a stop hook that refuses to end a turn with no spoken status
+banshee connect codex       # Codex CLI: the MCP server in ~/.codex/config.toml
+banshee connect cursor      # Cursor: the MCP server in ~/.cursor/mcp.json
+banshee connect opencode    # OpenCode: the MCP server
+banshee connect pi          # Pi: the native extension
+```
+
+Each command shows the exact change to that tool's config and asks before it writes.
+The Claude Code hook needs `jq` on your PATH. Antigravity, Claude Code, OpenCode
+and Pi are verified on a real install; Codex and Cursor follow their published config formats
+and wait for a report from a machine that has them.
+Restart the tool afterwards.
+
+`banshee-mcp-shim` is the MCP stdio server behind this. It exposes three tools:
 
 | Tool                | What the agent does with it                                       |
 | ------------------- | ----------------------------------------------------------------- |
@@ -202,7 +217,7 @@ exposes three tools:
 | `ask_user`          | Ask a question aloud, then wait for and return your spoken answer |
 | `listen_for_prompt` | Pick up anything you've said since it last checked                |
 
-Most MCP tools use the same `mcpServers` config shape:
+Any other MCP host takes the same `mcpServers` shape.
 
 ```json
 {
@@ -214,21 +229,12 @@ Most MCP tools use the same `mcpServers` config shape:
 }
 ```
 
-Each tool keeps this config in its own spot — Cursor in `~/.cursor/mcp.json`,
-Claude Code via `claude mcp add` — so check your tool's docs. If the binary is
-not found, use its full path. Restart the tool, and the three tools show up.
+If the binary is not found, use its full path.
 
 ### Pi coding agent
 
-Pi has its own extension API instead of MCP, so it gets a native extension that
-talks to the daemon directly. Copy it in and restart Pi:
-
-```bash
-cp integrations/pi/banshee.ts ~/.pi/agent/extensions/
-```
-
-That's the whole setup; see [integrations/pi](integrations/pi) for details.
-This is what the demo at the top is running.
+Pi has its own extension API instead of MCP, so `banshee connect pi` installs a native
+extension that talks to the daemon directly. See [integrations/pi](integrations/pi).
 
 ---
 

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -25,6 +25,7 @@ cpal = "0.17.3"
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"
 enigo = "0.6.1"
+json5 = "0.4"
 # Default "espeak" feature is off on purpose: it links espeak-ng via cmake and
 # needs an espeak-ng-data dir next to the binary at runtime, which a single-file
 # release install has no place for. text_to_speech::oov shells out instead.
@@ -39,7 +40,8 @@ rodio = { version = "0.22.2", default-features = false, features = ["playback"] 
 rubato = "3.0.0"
 rusqlite = { version = "0.40.1", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+similar = "2"
 tokio = { version = "1.52.3", features = ["full"] }
 toml = "1.1.2"
 toml_edit = { version = "0.25", features = ["serde"] }

--- a/bansheed/src/args.rs
+++ b/bansheed/src/args.rs
@@ -62,6 +62,24 @@ pub enum CommandType {
         #[clap(subcommand)]
         action: ServiceAction,
     },
+    /// Connect a coding agent to Banshee: Antigravity, Claude Code, Codex, Cursor, OpenCode or Pi
+    Connect {
+        /// Which agent; omit to list what is installed and connected
+        agent: Option<AgentName>,
+        /// Apply without asking
+        #[clap(long)]
+        yes: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum AgentName {
+    Antigravity,
+    Claude,
+    Codex,
+    Cursor,
+    Opencode,
+    Pi,
 }
 
 #[derive(Debug, Subcommand)]

--- a/bansheed/src/connect.rs
+++ b/bansheed/src/connect.rs
@@ -1,0 +1,1669 @@
+use banshee_common::error::BansheeError;
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Agent {
+    Antigravity,
+    ClaudeCode,
+    Codex,
+    Cursor,
+    OpenCode,
+    Pi,
+}
+
+impl Agent {
+    pub const ALL: [Agent; 6] = [
+        Agent::Antigravity,
+        Agent::ClaudeCode,
+        Agent::Codex,
+        Agent::Cursor,
+        Agent::OpenCode,
+        Agent::Pi,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Agent::Antigravity => "antigravity",
+            Agent::ClaudeCode => "claude",
+            Agent::Codex => "codex",
+            Agent::Cursor => "cursor",
+            Agent::OpenCode => "opencode",
+            Agent::Pi => "pi",
+        }
+    }
+
+    fn signal(self) -> Signal {
+        match self {
+            Agent::Antigravity => Signal::OnPath("agy"),
+            Agent::ClaudeCode => Signal::OnPath("claude"),
+            Agent::Codex => Signal::OnPath("codex"),
+            Agent::Cursor => Signal::HomeDir(".cursor"),
+            Agent::OpenCode => Signal::HomeDir(".config/opencode"),
+            Agent::Pi => Signal::HomeDir(".pi/agent"),
+        }
+    }
+}
+
+/// What tells `detect` that an agent is installed.
+enum Signal {
+    OnPath(&'static str),
+    HomeDir(&'static str),
+}
+
+impl From<crate::args::AgentName> for Agent {
+    fn from(name: crate::args::AgentName) -> Agent {
+        match name {
+            crate::args::AgentName::Antigravity => Agent::Antigravity,
+            crate::args::AgentName::Claude => Agent::ClaudeCode,
+            crate::args::AgentName::Codex => Agent::Codex,
+            crate::args::AgentName::Cursor => Agent::Cursor,
+            crate::args::AgentName::Opencode => Agent::OpenCode,
+            crate::args::AgentName::Pi => Agent::Pi,
+        }
+    }
+}
+
+/// Everything `detect` and `plan` read from the machine, so tests can point
+/// them at a scratch directory.
+pub struct Env {
+    pub home: PathBuf,
+    pub claude_config_dir: PathBuf,
+    pub banshee: PathBuf,
+    /// None when the shim does not ship beside `banshee`. Only Pi works then.
+    pub shim: Option<PathBuf>,
+    /// The agent binaries found on PATH.
+    pub on_path: Vec<&'static str>,
+    /// The command Claude Code has registered for the banshee MCP server.
+    pub claude_shim: Option<String>,
+    /// PATH resolves the bare name `banshee-mcp-shim` to `shim`.
+    pub shim_on_path: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Presence {
+    NotInstalled { looked_for: String },
+    Installed,
+}
+
+/// One edit to another tool's config, shown before it is applied.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Change {
+    Run {
+        argv: Vec<String>,
+    },
+    WriteFile {
+        path: PathBuf,
+        before: Option<String>,
+        after: String,
+        executable: bool,
+    },
+}
+
+pub fn detect(agent: Agent, env: &Env) -> Presence {
+    let (present, looked_for) = match agent.signal() {
+        Signal::OnPath(binary) => (env.on_path.contains(&binary), format!("{binary} on PATH")),
+        Signal::HomeDir(dir) => (env.home.join(dir).is_dir(), format!("~/{dir}/")),
+    };
+    if present {
+        Presence::Installed
+    } else {
+        Presence::NotInstalled { looked_for }
+    }
+}
+
+const PI_EXTENSION: &str = include_str!("../../integrations/pi/banshee.ts");
+
+const HOOK_SCRIPT: &str = include_str!("../../integrations/claude-code/banshee-speak-check.sh");
+
+// A hook does not get the login shell's PATH, so the script carries the path
+fn hook_script(banshee: &Path) -> String {
+    HOOK_SCRIPT.replace("@BANSHEE_BIN@", &banshee.display().to_string())
+}
+
+fn require_shim(env: &Env) -> Result<&Path, BansheeError> {
+    env.shim.as_deref().ok_or_else(|| {
+        BansheeError::Rejected(format!(
+            "banshee-mcp-shim is not beside {}; reinstall so they ship together",
+            env.banshee.display()
+        ))
+    })
+}
+
+pub(crate) const SHIM_NAME: &str = "banshee-mcp-shim";
+
+fn reaches_shim(registered: Option<&str>, shim: &Path, shim_on_path: bool) -> bool {
+    let Some(command) = registered else {
+        return false;
+    };
+    if command == SHIM_NAME {
+        return shim_on_path;
+    }
+    let command = Path::new(command);
+    command == shim || same_file(command, shim)
+}
+
+// A registered symlink and the canonical shim are one file
+fn same_file(a: &Path, b: &Path) -> bool {
+    matches!(
+        (std::fs::canonicalize(a), std::fs::canonicalize(b)),
+        (Ok(a), Ok(b)) if a == b
+    )
+}
+
+fn plan_claude(env: &Env) -> Result<Vec<Change>, BansheeError> {
+    let shim_path = require_shim(env)?;
+    let shim = shim_path.display().to_string();
+    let mut changes = Vec::new();
+    if !reaches_shim(env.claude_shim.as_deref(), shim_path, env.shim_on_path) {
+        // `claude mcp add` refuses a name it already holds, so a stale command
+        // has to go first
+        if env.claude_shim.is_some() {
+            changes.push(Change::Run {
+                argv: ["claude", "mcp", "remove", "--scope", "user", "banshee"]
+                    .map(String::from)
+                    .to_vec(),
+            });
+        }
+        changes.push(Change::Run {
+            argv: ["claude", "mcp", "add", "--scope", "user", "banshee", "--"]
+                .into_iter()
+                .map(String::from)
+                .chain(std::iter::once(shim))
+                .collect(),
+        });
+    }
+
+    let script_path = env.claude_config_dir.join("hooks").join(HOOK_SCRIPT_NAME);
+    let script = hook_script(&env.banshee);
+    match registered_stop_hook(&env.claude_config_dir)?
+        .as_deref()
+        .and_then(hook_script_path)
+    {
+        None => {
+            changes.extend(write_if_changed(script_path.clone(), &script, true)?);
+            let command = format!("bash '{}'", script_path.display());
+            changes.extend(rewrite(
+                env.claude_config_dir.join("settings.json"),
+                |settings| with_stop_hook(settings, &command),
+            )?);
+        }
+        Some(registered) if registered == script_path || !registered.exists() => {
+            changes.extend(write_if_changed(registered, &script, true)?);
+        }
+        // A working hook of the user's own, at a path of their own
+        Some(_) => {}
+    }
+    Ok(changes)
+}
+
+// Claude Code merges hooks from both files, so a hook in either one counts
+fn registered_stop_hook(claude_config_dir: &Path) -> Result<Option<String>, BansheeError> {
+    for file in ["settings.json", "settings.local.json"] {
+        let settings = read_if_present(&claude_config_dir.join(file))?;
+        if let Some(command) = stop_hook_command(&parse_settings(settings.as_deref())?) {
+            return Ok(Some(command));
+        }
+    }
+    Ok(None)
+}
+
+fn hook_script_path(command: &str) -> Option<PathBuf> {
+    command
+        .split_whitespace()
+        .find(|word| word.contains(HOOK_SCRIPT_NAME))
+        .map(|word| PathBuf::from(word.trim_matches(|c| c == '\'' || c == '"')))
+}
+
+pub fn plan(agent: Agent, env: &Env) -> Result<Vec<Change>, BansheeError> {
+    match agent {
+        Agent::ClaudeCode => plan_claude(env),
+        Agent::Codex => {
+            let shim = require_shim(env)?;
+            rewrite(env.home.join(".codex/config.toml"), |before| {
+                with_codex_server(before, shim, env.shim_on_path)
+            })
+        }
+        Agent::Cursor => {
+            let shim = require_shim(env)?;
+            rewrite(env.home.join(".cursor/mcp.json"), |before| {
+                with_mcp_server(before, "mcp.json", shim, env.shim_on_path)
+            })
+        }
+        // The IDE, the `agy` CLI and the SDK share this one file
+        Agent::Antigravity => {
+            let shim = require_shim(env)?;
+            rewrite(env.home.join(".gemini/config/mcp_config.json"), |before| {
+                with_mcp_server(before, "mcp_config.json", shim, env.shim_on_path)
+            })
+        }
+        Agent::OpenCode => {
+            let shim = require_shim(env)?;
+            rewrite(env.home.join(".config/opencode/opencode.jsonc"), |before| {
+                with_opencode_server(before, shim, env.shim_on_path)
+            })
+        }
+        Agent::Pi => Ok(write_if_changed(
+            env.home.join(".pi/agent/extensions/banshee.ts"),
+            PI_EXTENSION,
+            false,
+        )?
+        .into_iter()
+        .collect()),
+    }
+}
+
+fn read_if_present(path: &Path) -> Result<Option<String>, BansheeError> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok(Some(text)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+// json5 reads the comments and trailing commas that serde_json refuses; the rewrite is plain JSON
+fn with_opencode_server(
+    config: Option<&str>,
+    shim: &Path,
+    shim_on_path: bool,
+) -> Result<Option<String>, BansheeError> {
+    let mut root: serde_json::Value = match config {
+        Some(text) => json5::from_str(text)
+            .map_err(|error| malformed("opencode.jsonc", &format!("could not be read: {error}")))?,
+        None => serde_json::json!({}),
+    };
+    let entry = root
+        .as_object_mut()
+        .ok_or_else(|| malformed("opencode.jsonc", "is not a JSON object"))?
+        .entry("mcp")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed("opencode.jsonc", "mcp is not an object"))?
+        .entry("banshee")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed("opencode.jsonc", "mcp.banshee is not an object"))?;
+    let command = entry
+        .get("command")
+        .and_then(serde_json::Value::as_array)
+        .filter(|argv| argv.len() == 1)
+        .and_then(|argv| argv[0].as_str());
+    // OpenCode treats a missing `enabled` as true
+    let enabled = entry.get("enabled") != Some(&serde_json::Value::Bool(false));
+    if enabled
+        && entry.get("type") == Some(&serde_json::json!("local"))
+        && reaches_shim(command, shim, shim_on_path)
+    {
+        return Ok(None);
+    }
+    entry.insert("type".into(), serde_json::json!("local"));
+    entry.insert("enabled".into(), serde_json::json!(true));
+    entry.insert(
+        "command".into(),
+        serde_json::json!([shim.display().to_string()]),
+    );
+    Ok(Some(pretty_json(&root)?))
+}
+
+fn malformed(file: &str, what: &str) -> BansheeError {
+    BansheeError::Rejected(format!("{file} {what}"))
+}
+
+fn pretty_json(root: &serde_json::Value) -> Result<String, BansheeError> {
+    let mut text = serde_json::to_string_pretty(root)?;
+    text.push('\n');
+    Ok(text)
+}
+
+fn rewrite(
+    path: PathBuf,
+    edit: impl FnOnce(Option<&str>) -> Result<Option<String>, BansheeError>,
+) -> Result<Vec<Change>, BansheeError> {
+    let before = read_if_present(&path)?;
+    Ok(edit(before.as_deref())?
+        .map(|after| Change::WriteFile {
+            path,
+            before,
+            after,
+            executable: false,
+        })
+        .into_iter()
+        .collect())
+}
+
+fn with_mcp_server(
+    config: Option<&str>,
+    file: &str,
+    shim: &Path,
+    shim_on_path: bool,
+) -> Result<Option<String>, BansheeError> {
+    let mut root: serde_json::Value = match config {
+        Some(text) => json5::from_str(text)
+            .map_err(|error| malformed(file, &format!("could not be read: {error}")))?,
+        None => serde_json::json!({}),
+    };
+    let entry = root
+        .as_object_mut()
+        .ok_or_else(|| malformed(file, "is not a JSON object"))?
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed(file, "mcpServers is not an object"))?
+        .entry("banshee")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed(file, "mcpServers.banshee is not an object"))?;
+    let command = entry.get("command").and_then(serde_json::Value::as_str);
+    if reaches_shim(command, shim, shim_on_path) {
+        return Ok(None);
+    }
+    entry.insert(
+        "command".into(),
+        serde_json::json!(shim.display().to_string()),
+    );
+    Ok(Some(pretty_json(&root)?))
+}
+
+// toml_edit keeps the user's comments
+fn with_codex_server(
+    config: Option<&str>,
+    shim: &Path,
+    shim_on_path: bool,
+) -> Result<Option<String>, BansheeError> {
+    let mut document: toml_edit::DocumentMut = config
+        .unwrap_or_default()
+        .parse()
+        .map_err(|error| malformed("config.toml", &format!("could not be read: {error}")))?;
+    let servers = document
+        .as_table_mut()
+        .entry("mcp_servers")
+        .or_insert_with(|| {
+            let mut table = toml_edit::Table::new();
+            table.set_implicit(true);
+            toml_edit::Item::Table(table)
+        })
+        .as_table_mut()
+        .ok_or_else(|| malformed("config.toml", "mcp_servers is not a table"))?;
+    let banshee = servers
+        .entry("banshee")
+        .or_insert(toml_edit::table())
+        .as_table_mut()
+        .ok_or_else(|| malformed("config.toml", "mcp_servers.banshee is not a table"))?;
+    let command = banshee.get("command").and_then(toml_edit::Item::as_str);
+    if reaches_shim(command, shim, shim_on_path) {
+        return Ok(None);
+    }
+    banshee["command"] = toml_edit::value(shim.display().to_string());
+    Ok(Some(document.to_string()))
+}
+
+fn write_if_changed(
+    path: PathBuf,
+    after: &str,
+    executable: bool,
+) -> Result<Option<Change>, BansheeError> {
+    let before = read_if_present(&path)?;
+    if before.as_deref() == Some(after) {
+        return Ok(None);
+    }
+    Ok(Some(Change::WriteFile {
+        path,
+        before,
+        after: after.to_string(),
+        executable,
+    }))
+}
+
+pub(crate) const HOOK_SCRIPT_NAME: &str = "banshee-speak-check.sh";
+
+fn parse_settings(settings: Option<&str>) -> Result<serde_json::Value, BansheeError> {
+    match settings {
+        Some(text) => serde_json::from_str(text)
+            .map_err(|error| malformed("settings.json", &format!("is not valid JSON: {error}"))),
+        None => Ok(serde_json::json!({})),
+    }
+}
+
+fn stop_hook_command(root: &serde_json::Value) -> Option<String> {
+    root["hooks"]["Stop"]
+        .as_array()?
+        .iter()
+        .flat_map(|group| group["hooks"].as_array().into_iter().flatten())
+        .filter_map(|hook| hook["command"].as_str())
+        .find(|command| command.contains(HOOK_SCRIPT_NAME))
+        .map(String::from)
+}
+
+// Whole file in, whole file out, so key order matches what Claude Code writes
+fn with_stop_hook(settings: Option<&str>, command: &str) -> Result<Option<String>, BansheeError> {
+    let mut root = parse_settings(settings)?;
+    if stop_hook_command(&root).is_some() {
+        return Ok(None);
+    }
+    let object = root
+        .as_object_mut()
+        .ok_or_else(|| malformed("settings.json", "is not a JSON object"))?;
+    let stop = object
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed("settings.json", "hooks is not an object"))?
+        .entry("Stop")
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .ok_or_else(|| malformed("settings.json", "hooks.Stop is not a list"))?;
+    stop.push(serde_json::json!({
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "timeout": 15,
+            "statusMessage": "Checking you spoke",
+        }]
+    }));
+    Ok(Some(pretty_json(&root)?))
+}
+
+pub fn render(change: &Change) -> String {
+    match change {
+        Change::Run { argv } => {
+            let words: Vec<String> = argv.iter().map(|word| shell_word(word)).collect();
+            format!("$ {}\n", words.join(" "))
+        }
+        Change::WriteFile {
+            path,
+            before: None,
+            after,
+            ..
+        } => {
+            format!(
+                "new file {}, {} lines\n",
+                path.display(),
+                after.lines().count()
+            )
+        }
+        Change::WriteFile {
+            path,
+            before: Some(before),
+            after,
+            ..
+        } => {
+            let name = path.display().to_string();
+            similar::TextDiff::from_lines(before.as_str(), after.as_str())
+                .unified_diff()
+                .header(&name, &name)
+                .to_string()
+        }
+    }
+}
+
+// Single quotes are enough for a path; the command is shown, never re-parsed
+fn shell_word(word: &str) -> String {
+    let plain = word
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "-_./=:".contains(c));
+    if plain {
+        word.to_string()
+    } else {
+        format!("'{}'", word.replace('\'', "'\\''"))
+    }
+}
+
+pub fn apply(change: &Change) -> Result<(), BansheeError> {
+    match change {
+        Change::Run { argv } => {
+            let Some(program) = argv.first() else {
+                return Err(BansheeError::Other("a command with no program".into()));
+            };
+            let status = std::process::Command::new(program)
+                .args(&argv[1..])
+                .status()?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(BansheeError::Other(format!(
+                    "{program} exited with {status}"
+                )))
+            }
+        }
+        Change::WriteFile {
+            path,
+            after,
+            executable,
+            ..
+        } => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            // A partial write would truncate a file another tool owns
+            let staged = path.with_extension(format!("banshee.{}", std::process::id()));
+            std::fs::write(&staged, after)?;
+            if *executable {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))?;
+            }
+            std::fs::rename(&staged, path)?;
+            Ok(())
+        }
+    }
+}
+
+pub fn confirm(prompt: &str) -> Result<bool, BansheeError> {
+    print!("{prompt}");
+    std::io::stdout().flush()?;
+    let mut answer = String::new();
+    std::io::stdin().lock().read_line(&mut answer)?;
+    Ok(matches!(answer.trim(), "y" | "Y" | "yes"))
+}
+
+// Claude Code owns this file: connect only reads it, and unreadable means unregistered
+fn registered_claude_shim(global_config: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(global_config).ok()?;
+    let root: serde_json::Value = serde_json::from_str(&text).ok()?;
+    root.get("mcpServers")?
+        .get("banshee")?
+        .get("command")?
+        .as_str()
+        .map(String::from)
+}
+
+fn path_resolves_to_shim(shim: &Path) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    let Ok(real) = std::fs::canonicalize(shim) else {
+        return false;
+    };
+    std::env::split_paths(&path)
+        .filter_map(|dir| std::fs::canonicalize(dir.join(SHIM_NAME)).ok())
+        .any(|found| found == real)
+}
+
+impl Env {
+    pub fn from_machine() -> Result<Env, BansheeError> {
+        let home = crate::service::home_dir()?;
+        let config_dir_override = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
+        // Claude Code keeps user-scope servers in ~/.claude.json unless the variable moves them
+        let claude_global = match &config_dir_override {
+            Some(dir) => dir.join(".claude.json"),
+            None => home.join(".claude.json"),
+        };
+        let claude_config_dir = config_dir_override.unwrap_or_else(|| home.join(".claude"));
+        let exe = std::env::current_exe()?;
+        let banshee = std::fs::canonicalize(&exe)?;
+        let shim = crate::service::sibling(&exe, SHIM_NAME).ok();
+        let shim_on_path = shim.as_deref().is_some_and(path_resolves_to_shim);
+        // Starting Claude Code makes it rewrite its own config, so detection never spawns an agent
+        let on_path = Agent::ALL
+            .iter()
+            .filter_map(|agent| match agent.signal() {
+                Signal::OnPath(binary) => Some(binary),
+                Signal::HomeDir(_) => None,
+            })
+            .filter(|binary| crate::status::on_path(binary))
+            .collect();
+        Ok(Env {
+            home,
+            claude_config_dir,
+            banshee,
+            shim,
+            on_path,
+            claude_shim: registered_claude_shim(&claude_global),
+            shim_on_path,
+        })
+    }
+}
+
+pub fn run(agent: Option<Agent>, yes: bool) -> Result<(), BansheeError> {
+    let env = Env::from_machine()?;
+    let Some(agent) = agent else {
+        return list(&env);
+    };
+    if let Presence::NotInstalled { looked_for } = detect(agent, &env) {
+        return Err(BansheeError::Rejected(format!(
+            "{} is not installed here (looked for {looked_for})",
+            agent.name()
+        )));
+    }
+    let changes = plan(agent, &env)?;
+    if changes.is_empty() {
+        println!("{} is already connected.", agent.name());
+        return Ok(());
+    }
+    for change in &changes {
+        print!("{}", render(change));
+        println!();
+    }
+    if !yes && !confirm("Apply? [y/N] ")? {
+        return Err(BansheeError::Rejected("Nothing written.".into()));
+    }
+    for (done, change) in changes.iter().enumerate() {
+        if let Err(error) = apply(change) {
+            let left: String = changes[done..].iter().map(render).collect();
+            return Err(BansheeError::Rejected(format!(
+                "{error}\n{done} of {} changes applied. Still to apply:\n{left}",
+                changes.len()
+            )));
+        }
+        if let Change::WriteFile { path, .. } = change {
+            println!("wrote {}", path.display());
+        }
+    }
+    println!(
+        "{} is connected. Restart it to pick up the change.",
+        agent.name()
+    );
+    Ok(())
+}
+
+fn list(env: &Env) -> Result<(), BansheeError> {
+    let width = Agent::ALL
+        .iter()
+        .map(|agent| agent.name().len())
+        .max()
+        .unwrap_or(0);
+    for agent in Agent::ALL {
+        // One agent that cannot be planned must not hide the other rows
+        let line = match detect(agent, env) {
+            Presence::NotInstalled { looked_for } => format!("not found   ({looked_for})"),
+            Presence::Installed => match plan(agent, env) {
+                Err(error) => format!("installed   error: {error}"),
+                Ok(changes) if changes.is_empty() => "installed   connected".to_string(),
+                Ok(_) => "installed   not connected".to_string(),
+            },
+        };
+        println!("{:<width$} {line}", agent.name());
+    }
+    println!();
+    println!("Connect one with: banshee connect <agent>");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    pub(super) fn scratch(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("banshee-connect-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    pub(super) fn env_at(home: &std::path::Path) -> Env {
+        Env {
+            home: home.to_path_buf(),
+            claude_config_dir: home.join(".claude"),
+            banshee: PathBuf::from("/opt/banshee/bin/banshee"),
+            shim: Some(PathBuf::from("/opt/banshee/bin/banshee-mcp-shim")),
+            on_path: Vec::new(),
+            claude_shim: None,
+            shim_on_path: false,
+        }
+    }
+
+    const SHIM: &str = "/opt/banshee/bin/banshee-mcp-shim";
+
+    #[test]
+    fn cursor_is_installed_when_its_dir_exists_and_the_clis_when_on_path() {
+        let home = scratch("detect-new");
+        let mut env = env_at(&home);
+        assert_eq!(
+            detect(Agent::Cursor, &env),
+            Presence::NotInstalled {
+                looked_for: "~/.cursor/".into()
+            }
+        );
+        assert_eq!(
+            detect(Agent::Codex, &env),
+            Presence::NotInstalled {
+                looked_for: "codex on PATH".into()
+            }
+        );
+        assert_eq!(
+            detect(Agent::Antigravity, &env),
+            Presence::NotInstalled {
+                looked_for: "agy on PATH".into()
+            }
+        );
+        std::fs::create_dir_all(home.join(".cursor")).unwrap();
+        env.on_path.push("codex");
+        env.on_path.push("agy");
+        assert_eq!(detect(Agent::Cursor, &env), Presence::Installed);
+        assert_eq!(detect(Agent::Codex, &env), Presence::Installed);
+        assert_eq!(detect(Agent::Antigravity, &env), Presence::Installed);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn mcp_server_is_added_to_a_missing_file() {
+        let after = with_mcp_server(None, "mcp.json", Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({ "mcpServers": { "banshee": { "command": SHIM } } })
+        );
+        assert!(after.ends_with("}\n"));
+    }
+
+    #[test]
+    fn mcp_server_keeps_other_servers_and_key_order() {
+        let before = "{\n  \"theme\": \"dark\",\n  \"mcpServers\": {\n    \"other\": { \"command\": \"x\" },\n  },\n}\n";
+        let after = with_mcp_server(Some(before), "settings.json", Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value["theme"], "dark");
+        assert_eq!(value["mcpServers"]["other"]["command"], "x");
+        assert_eq!(value["mcpServers"]["banshee"]["command"], SHIM);
+        let keys: Vec<&String> = value.as_object().unwrap().keys().collect();
+        assert_eq!(keys, ["theme", "mcpServers"]);
+    }
+
+    #[test]
+    fn mcp_server_that_reaches_the_shim_means_no_change() {
+        let absolute = format!(r#"{{"mcpServers":{{"banshee":{{"command":"{SHIM}"}}}}}}"#);
+        assert_eq!(
+            with_mcp_server(Some(&absolute), "mcp.json", Path::new(SHIM), false).unwrap(),
+            None
+        );
+        let bare = r#"{"mcpServers":{"banshee":{"command":"banshee-mcp-shim"}}}"#;
+        assert_eq!(
+            with_mcp_server(Some(bare), "mcp.json", Path::new(SHIM), true).unwrap(),
+            None
+        );
+        assert!(
+            with_mcp_server(Some(bare), "mcp.json", Path::new(SHIM), false)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn mcp_server_errors_name_the_file() {
+        let error = with_mcp_server(Some("[1]"), "mcp.json", Path::new(SHIM), false)
+            .expect_err("not an object");
+        assert!(error.to_string().starts_with("mcp.json "), "{error}");
+    }
+
+    #[test]
+    fn codex_server_is_added_to_a_missing_file() {
+        let after = with_codex_server(None, Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        assert_eq!(
+            after,
+            format!("[mcp_servers.banshee]\ncommand = \"{SHIM}\"\n")
+        );
+    }
+
+    #[test]
+    fn codex_server_keeps_comments_and_other_tables() {
+        let before =
+            "# my codex config\nmodel = \"o3\" # keep\n\n[mcp_servers.other]\ncommand = \"x\"\n";
+        let after = with_codex_server(Some(before), Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        assert!(
+            after.starts_with("# my codex config\nmodel = \"o3\" # keep\n"),
+            "{after}"
+        );
+        assert!(
+            after.contains("[mcp_servers.other]\ncommand = \"x\"\n"),
+            "{after}"
+        );
+        assert!(
+            after.contains(&format!("[mcp_servers.banshee]\ncommand = \"{SHIM}\"\n")),
+            "{after}"
+        );
+    }
+
+    #[test]
+    fn codex_server_that_reaches_the_shim_means_no_change() {
+        let absolute = format!("[mcp_servers.banshee]\ncommand = \"{SHIM}\"\n");
+        assert_eq!(
+            with_codex_server(Some(&absolute), Path::new(SHIM), false).unwrap(),
+            None
+        );
+        let bare = "[mcp_servers.banshee]\ncommand = \"banshee-mcp-shim\"\n";
+        assert_eq!(
+            with_codex_server(Some(bare), Path::new(SHIM), true).unwrap(),
+            None
+        );
+        let stale = "[mcp_servers.banshee]\ncommand = \"/old/banshee-mcp-shim\"\nargs = []\n";
+        let after = with_codex_server(Some(stale), Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        assert!(after.contains(&format!("command = \"{SHIM}\"")), "{after}");
+        assert!(
+            after.contains("args = []"),
+            "other keys of the entry survive: {after}"
+        );
+    }
+
+    #[test]
+    fn codex_refuses_an_mcp_servers_that_is_not_a_table() {
+        for before in [
+            "mcp_servers = { banshee = { command = \"x\" } }\n",
+            "[[mcp_servers]]\ncommand = \"x\"\n",
+            "[mcp_servers]\nbanshee = { command = \"x\" }\n",
+        ] {
+            let error = with_codex_server(Some(before), Path::new(SHIM), false).expect_err(before);
+            assert!(
+                matches!(error, BansheeError::Rejected(_)),
+                "{before}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_server_refuses_an_mcp_servers_that_is_not_an_object() {
+        let error = with_mcp_server(
+            Some(r#"{"mcpServers":[1]}"#),
+            "mcp.json",
+            Path::new(SHIM),
+            false,
+        )
+        .expect_err("a list is not a server map");
+        assert!(matches!(error, BansheeError::Rejected(_)), "{error}");
+        assert_eq!(error.to_string(), "mcp.json mcpServers is not an object");
+    }
+
+    #[test]
+    fn codex_errors_name_the_file() {
+        let error =
+            with_codex_server(Some("not = = toml"), Path::new(SHIM), false).expect_err("bad toml");
+        assert!(error.to_string().starts_with("config.toml "), "{error}");
+    }
+
+    #[test]
+    fn the_new_agents_plan_their_own_files_and_need_the_shim() {
+        let home = scratch("plan-new");
+        let mut env = env_at(&home);
+        std::fs::create_dir_all(home.join(".cursor")).unwrap();
+        env.on_path.push("codex");
+        env.on_path.push("agy");
+        for (agent, file) in [
+            (Agent::Cursor, ".cursor/mcp.json"),
+            (Agent::Codex, ".codex/config.toml"),
+            (Agent::Antigravity, ".gemini/config/mcp_config.json"),
+        ] {
+            match &plan(agent, &env).unwrap()[..] {
+                [
+                    Change::WriteFile {
+                        path,
+                        before: None,
+                        executable: false,
+                        ..
+                    },
+                ] => {
+                    assert_eq!(path, &home.join(file));
+                }
+                other => panic!("{agent:?}: {other:?}"),
+            }
+        }
+        env.shim = None;
+        for agent in [Agent::Cursor, Agent::Codex, Agent::Antigravity] {
+            assert!(plan(agent, &env).is_err(), "{agent:?} must need the shim");
+        }
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn a_bare_shim_name_that_path_resolves_to_the_shim_is_connected() {
+        let home = scratch("claude-bare-on-path");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("banshee-mcp-shim".into());
+        env.shim_on_path = true;
+        let script = home.join(".claude/hooks/banshee-speak-check.sh");
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(&script, hook_script(&env.banshee)).unwrap();
+        std::fs::write(
+            home.join(".claude/settings.json"),
+            format!(
+                r#"{{"hooks":{{"Stop":[{{"hooks":[{{"type":"command","command":"bash '{}'"}}]}}]}}}}"#,
+                script.display()
+            ),
+        )
+        .unwrap();
+        assert!(plan(Agent::ClaudeCode, &env).unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn a_bare_shim_name_that_path_does_not_resolve_is_reissued() {
+        let home = scratch("claude-bare-off-path");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("banshee-mcp-shim".into());
+        env.shim_on_path = false;
+        let changes = plan(Agent::ClaudeCode, &env).unwrap();
+        assert!(
+            matches!(&changes[0], Change::Run { argv } if argv[2] == "remove"),
+            "{changes:?}"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn opencode_bare_shim_name_that_path_resolves_means_no_change() {
+        let before =
+            r#"{"mcp":{"banshee":{"type":"local","enabled":true,"command":["banshee-mcp-shim"]}}}"#;
+        let shim = std::path::Path::new("/opt/banshee/bin/banshee-mcp-shim");
+        assert_eq!(
+            with_opencode_server(Some(before), shim, true).unwrap(),
+            None
+        );
+        assert!(
+            with_opencode_server(Some(before), shim, false)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn claude_is_installed_when_on_path() {
+        let home = scratch("detect-claude");
+        let mut env = env_at(&home);
+        assert_eq!(
+            detect(Agent::ClaudeCode, &env),
+            Presence::NotInstalled {
+                looked_for: "claude on PATH".into()
+            }
+        );
+        env.on_path.push("claude");
+        assert_eq!(detect(Agent::ClaudeCode, &env), Presence::Installed);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn opencode_is_installed_when_its_config_dir_exists() {
+        let home = scratch("detect-opencode");
+        let env = env_at(&home);
+        assert_eq!(
+            detect(Agent::OpenCode, &env),
+            Presence::NotInstalled {
+                looked_for: "~/.config/opencode/".into()
+            }
+        );
+        std::fs::create_dir_all(home.join(".config/opencode")).unwrap();
+        assert_eq!(detect(Agent::OpenCode, &env), Presence::Installed);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn pi_is_installed_when_its_agent_dir_exists() {
+        let home = scratch("detect-pi");
+        let env = env_at(&home);
+        assert_eq!(
+            detect(Agent::Pi, &env),
+            Presence::NotInstalled {
+                looked_for: "~/.pi/agent/".into()
+            }
+        );
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        assert_eq!(detect(Agent::Pi, &env), Presence::Installed);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn every_agent_has_a_cli_name() {
+        let names: Vec<&str> = Agent::ALL.iter().map(|a| a.name()).collect();
+        assert_eq!(
+            names,
+            ["antigravity", "claude", "codex", "cursor", "opencode", "pi"]
+        );
+    }
+
+    #[test]
+    fn pi_plan_writes_the_extension_when_absent() {
+        let home = scratch("pi-absent");
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        let changes = plan(Agent::Pi, &env_at(&home)).unwrap();
+        assert_eq!(
+            changes,
+            vec![Change::WriteFile {
+                path: home.join(".pi/agent/extensions/banshee.ts"),
+                before: None,
+                after: PI_EXTENSION.to_string(),
+                executable: false,
+            }]
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn pi_plan_shows_the_old_text_when_it_differs() {
+        let home = scratch("pi-stale");
+        let path = home.join(".pi/agent/extensions/banshee.ts");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "// old\n").unwrap();
+        let changes = plan(Agent::Pi, &env_at(&home)).unwrap();
+        assert_eq!(changes.len(), 1);
+        match &changes[0] {
+            Change::WriteFile { before, .. } => assert_eq!(before.as_deref(), Some("// old\n")),
+            other => panic!("expected a file write, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn pi_plan_is_empty_when_already_connected() {
+        let home = scratch("pi-connected");
+        let path = home.join(".pi/agent/extensions/banshee.ts");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, PI_EXTENSION).unwrap();
+        assert!(plan(Agent::Pi, &env_at(&home)).unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn a_hook_is_added_to_settings_with_no_hooks() {
+        let before = "{\n  \"model\": \"opus\",\n  \"theme\": \"dark\"\n}\n";
+        let after = with_stop_hook(Some(before), "bash '/x/banshee-speak-check.sh'")
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value["model"], "opus");
+        assert_eq!(value["theme"], "dark");
+        assert_eq!(
+            value["hooks"]["Stop"][0],
+            serde_json::json!({ "hooks": [{
+                "type": "command",
+                "command": "bash '/x/banshee-speak-check.sh'",
+                "timeout": 15,
+                "statusMessage": "Checking you spoke",
+            }] })
+        );
+        // Key order and indentation survive, so the diff shows only the addition
+        assert!(
+            after.starts_with("{\n  \"model\": \"opus\",\n  \"theme\": \"dark\",\n  \"hooks\""),
+            "{after}"
+        );
+        assert!(after.ends_with("}\n"));
+    }
+
+    #[test]
+    fn a_hook_is_appended_after_other_stop_hooks() {
+        let before = r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}"#;
+        let after = with_stop_hook(Some(before), "bash '/x/banshee-speak-check.sh'")
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value["hooks"]["Stop"][0]["hooks"][0]["command"], "echo hi");
+        assert_eq!(
+            value["hooks"]["Stop"][1]["hooks"][0]["command"],
+            "bash '/x/banshee-speak-check.sh'"
+        );
+    }
+
+    #[test]
+    fn a_hook_already_present_at_any_path_means_no_change() {
+        let before = r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"bash '/elsewhere/hooks/banshee-speak-check.sh'"}]}]}}"#;
+        assert_eq!(
+            with_stop_hook(Some(before), "bash '/x/banshee-speak-check.sh'").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn a_missing_settings_file_gets_only_the_hook() {
+        let after = with_stop_hook(None, "bash '/x/banshee-speak-check.sh'")
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value.as_object().unwrap().len(), 1);
+        assert_eq!(
+            value["hooks"]["Stop"][0]["hooks"][0]["command"],
+            "bash '/x/banshee-speak-check.sh'"
+        );
+    }
+
+    #[test]
+    fn unreadable_settings_are_an_error_not_a_rewrite() {
+        let error = with_stop_hook(Some("{ not json"), "x").expect_err("must not guess");
+        assert!(error.to_string().contains("settings.json"), "{error}");
+    }
+
+    #[test]
+    fn the_hook_script_names_the_installed_binary() {
+        let script = hook_script(std::path::Path::new("/opt/banshee/bin/banshee"));
+        assert!(
+            script.contains("banshee=\"${BANSHEE_BIN:-/opt/banshee/bin/banshee}\""),
+            "{script}"
+        );
+        assert!(!script.contains("@BANSHEE_BIN@"));
+    }
+
+    #[test]
+    fn claude_plan_adds_the_server_the_script_and_the_hook() {
+        let home = scratch("claude-fresh");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        let changes = plan(Agent::ClaudeCode, &env).unwrap();
+        assert_eq!(changes.len(), 3, "{changes:?}");
+        assert_eq!(
+            changes[0],
+            Change::Run {
+                argv: [
+                    "claude",
+                    "mcp",
+                    "add",
+                    "--scope",
+                    "user",
+                    "banshee",
+                    "--",
+                    "/opt/banshee/bin/banshee-mcp-shim"
+                ]
+                .map(String::from)
+                .to_vec()
+            }
+        );
+        match &changes[1] {
+            Change::WriteFile {
+                path,
+                before,
+                executable,
+                ..
+            } => {
+                assert_eq!(path, &home.join(".claude/hooks/banshee-speak-check.sh"));
+                assert_eq!(*before, None);
+                assert!(executable);
+            }
+            other => panic!("{other:?}"),
+        }
+        match &changes[2] {
+            Change::WriteFile {
+                path,
+                after,
+                executable,
+                ..
+            } => {
+                assert_eq!(path, &home.join(".claude/settings.json"));
+                assert!(!executable);
+                let expected = format!(
+                    "bash '{}'",
+                    home.join(".claude/hooks/banshee-speak-check.sh").display()
+                );
+                assert!(after.contains(&expected), "{after}");
+            }
+            other => panic!("{other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn claude_plan_skips_the_server_when_claude_already_has_it() {
+        let home = scratch("claude-has-mcp");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("/opt/banshee/bin/banshee-mcp-shim".into());
+        let changes = plan(Agent::ClaudeCode, &env).unwrap();
+        assert!(
+            !changes.iter().any(|c| matches!(c, Change::Run { .. })),
+            "{changes:?}"
+        );
+        assert_eq!(changes.len(), 2);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn claude_plan_leaves_a_working_hook_alone_wherever_its_script_lives() {
+        let home = scratch("claude-hook-elsewhere");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("/opt/banshee/bin/banshee-mcp-shim".into());
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        std::fs::create_dir_all(home.join("elsewhere")).unwrap();
+        std::fs::write(home.join("elsewhere/banshee-speak-check.sh"), "# theirs\n").unwrap();
+        std::fs::write(
+            home.join(".claude/settings.json"),
+            format!(
+                r#"{{"hooks":{{"Stop":[{{"hooks":[{{"type":"command","command":"bash '{}/elsewhere/banshee-speak-check.sh'"}}]}}]}}}}"#,
+                home.display()
+            ),
+        )
+        .unwrap();
+        assert!(plan(Agent::ClaudeCode, &env).unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn claude_plan_repairs_a_registered_script_that_is_missing() {
+        let home = scratch("claude-hook-missing");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("/opt/banshee/bin/banshee-mcp-shim".into());
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let registered = home.join("gone/banshee-speak-check.sh");
+        std::fs::write(
+            home.join(".claude/settings.json"),
+            format!(
+                r#"{{"hooks":{{"Stop":[{{"hooks":[{{"type":"command","command":"bash '{}'"}}]}}]}}}}"#,
+                registered.display()
+            ),
+        )
+        .unwrap();
+        match &plan(Agent::ClaudeCode, &env).unwrap()[..] {
+            [
+                Change::WriteFile {
+                    path,
+                    before: None,
+                    executable: true,
+                    ..
+                },
+            ] => {
+                assert_eq!(path, &registered)
+            }
+            other => panic!("{other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn a_hook_in_settings_local_counts_as_registered() {
+        let home = scratch("claude-hook-local");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("/opt/banshee/bin/banshee-mcp-shim".into());
+        let script = home.join(".claude/hooks/banshee-speak-check.sh");
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(&script, hook_script(&env.banshee)).unwrap();
+        std::fs::write(
+            home.join(".claude/settings.local.json"),
+            format!(
+                r#"{{"hooks":{{"Stop":[{{"hooks":[{{"type":"command","command":"bash '{}'"}}]}}]}}}}"#,
+                script.display()
+            ),
+        )
+        .unwrap();
+        assert!(plan(Agent::ClaudeCode, &env).unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn an_absolute_command_through_a_symlink_reaches_the_shim() {
+        let home = scratch("shim-symlink");
+        let real = home.join("app/banshee-mcp-shim");
+        std::fs::create_dir_all(home.join("app")).unwrap();
+        std::fs::create_dir_all(home.join("bin")).unwrap();
+        std::fs::write(&real, "").unwrap();
+        let link = home.join("bin/banshee-mcp-shim");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert!(reaches_shim(
+            Some(&link.display().to_string()),
+            &real,
+            false
+        ));
+        assert!(!reaches_shim(
+            Some("/nowhere/banshee-mcp-shim"),
+            &real,
+            false
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn json_hosts_keep_the_entry_other_keys() {
+        let before = r#"{"mcpServers":{"banshee":{"command":"/old/shim","env":{"KEEP":"me"}}}}"#;
+        let after = with_mcp_server(Some(before), "mcp.json", Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value["mcpServers"]["banshee"]["command"], SHIM);
+        assert_eq!(value["mcpServers"]["banshee"]["env"]["KEEP"], "me");
+
+        let before =
+            r#"{"mcp":{"banshee":{"type":"local","command":["/old/shim"],"timeout":20000}}}"#;
+        let after = with_opencode_server(Some(before), Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value["mcp"]["banshee"]["command"][0], SHIM);
+        assert_eq!(value["mcp"]["banshee"]["timeout"], 20000);
+    }
+
+    #[test]
+    fn opencode_entry_with_no_enabled_key_counts_as_enabled() {
+        let before = format!(r#"{{"mcp":{{"banshee":{{"type":"local","command":["{SHIM}"]}}}}}}"#);
+        assert_eq!(
+            with_opencode_server(Some(&before), Path::new(SHIM), false).unwrap(),
+            None
+        );
+        let disabled = format!(
+            r#"{{"mcp":{{"banshee":{{"type":"local","enabled":false,"command":["{SHIM}"]}}}}}}"#
+        );
+        let after = with_opencode_server(Some(&disabled), Path::new(SHIM), false)
+            .unwrap()
+            .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value["mcp"]["banshee"]["enabled"], true);
+    }
+
+    #[test]
+    fn claude_plan_honours_the_config_dir() {
+        let home = scratch("claude-config-dir");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("/opt/banshee/bin/banshee-mcp-shim".into());
+        env.claude_config_dir = home.join(".claude-work");
+        let changes = plan(Agent::ClaudeCode, &env).unwrap();
+        let paths: Vec<&PathBuf> = changes
+            .iter()
+            .filter_map(|c| match c {
+                Change::WriteFile { path, .. } => Some(path),
+                Change::Run { .. } => None,
+            })
+            .collect();
+        assert_eq!(
+            paths,
+            [
+                &home.join(".claude-work/hooks/banshee-speak-check.sh"),
+                &home.join(".claude-work/settings.json")
+            ]
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn opencode_server_is_added_to_a_jsonc_file_with_comments_and_trailing_commas() {
+        let before = "// top\n{\n  \"$schema\": \"https://opencode.ai/config.json\",\n  /* keep */ \"plugin\": [\n    \"a\",\n  ],\n  \"mcp\": {\n    \"other\": { \"type\": \"remote\", \"url\": \"https://x\", \"enabled\": false },\n  },\n}\n";
+        let after = with_opencode_server(
+            Some(before),
+            std::path::Path::new("/opt/banshee/bin/banshee-mcp-shim"),
+            false,
+        )
+        .unwrap()
+        .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value["$schema"], "https://opencode.ai/config.json");
+        assert_eq!(value["plugin"][0], "a");
+        assert_eq!(value["mcp"]["other"]["type"], "remote");
+        assert_eq!(value["mcp"]["banshee"]["type"], "local");
+        assert_eq!(value["mcp"]["banshee"]["enabled"], true);
+        assert_eq!(
+            value["mcp"]["banshee"]["command"][0],
+            "/opt/banshee/bin/banshee-mcp-shim"
+        );
+        let keys: Vec<&String> = value.as_object().unwrap().keys().collect();
+        assert_eq!(keys, ["$schema", "plugin", "mcp"], "key order must survive");
+    }
+
+    #[test]
+    fn opencode_server_is_updated_when_it_points_elsewhere() {
+        let before =
+            r#"{"mcp":{"banshee":{"type":"local","enabled":true,"command":["banshee-mcp-shim"]}}}"#;
+        let after = with_opencode_server(
+            Some(before),
+            std::path::Path::new("/opt/banshee/bin/banshee-mcp-shim"),
+            false,
+        )
+        .unwrap()
+        .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(
+            value["mcp"]["banshee"]["command"][0],
+            "/opt/banshee/bin/banshee-mcp-shim"
+        );
+    }
+
+    #[test]
+    fn opencode_server_already_pointing_at_the_shim_means_no_change() {
+        let before = r#"{"mcp":{"banshee":{"type":"local","enabled":true,"command":["/opt/banshee/bin/banshee-mcp-shim"]}}}"#;
+        assert_eq!(
+            with_opencode_server(
+                Some(before),
+                std::path::Path::new("/opt/banshee/bin/banshee-mcp-shim"),
+                false
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn a_missing_opencode_config_gets_only_the_server() {
+        let after = with_opencode_server(
+            None,
+            std::path::Path::new("/opt/banshee/bin/banshee-mcp-shim"),
+            false,
+        )
+        .unwrap()
+        .expect("a change");
+        let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+        assert_eq!(value.as_object().unwrap().len(), 1);
+        assert_eq!(
+            value["mcp"]["banshee"]["command"][0],
+            "/opt/banshee/bin/banshee-mcp-shim"
+        );
+    }
+
+    #[test]
+    fn a_command_renders_as_one_quoted_line() {
+        let change = Change::Run {
+            argv: [
+                "claude",
+                "mcp",
+                "add",
+                "--",
+                "/Applications/My Tools/banshee-mcp-shim",
+            ]
+            .map(String::from)
+            .to_vec(),
+        };
+        assert_eq!(
+            render(&change),
+            "$ claude mcp add -- '/Applications/My Tools/banshee-mcp-shim'\n"
+        );
+    }
+
+    #[test]
+    fn a_new_file_renders_as_a_line_count() {
+        let change = Change::WriteFile {
+            path: PathBuf::from("/h/.pi/agent/extensions/banshee.ts"),
+            before: None,
+            after: "a\nb\nc\n".into(),
+            executable: false,
+        };
+        assert_eq!(
+            render(&change),
+            "new file /h/.pi/agent/extensions/banshee.ts, 3 lines\n"
+        );
+    }
+
+    #[test]
+    fn a_changed_file_renders_as_a_unified_diff() {
+        let change = Change::WriteFile {
+            path: PathBuf::from("/h/settings.json"),
+            before: Some("{\n  \"a\": 1\n}\n".into()),
+            after: "{\n  \"a\": 1,\n  \"b\": 2\n}\n".into(),
+            executable: false,
+        };
+        let text = render(&change);
+        assert!(
+            text.starts_with("--- /h/settings.json\n+++ /h/settings.json\n"),
+            "{text}"
+        );
+        assert!(text.contains("+  \"b\": 2\n"), "{text}");
+        assert!(
+            text.contains("-  \"a\": 1\n") && text.contains("+  \"a\": 1,\n"),
+            "{text}"
+        );
+        // "a": 1 gains a trailing comma, so it is a real change (removed then
+        // re-added); only the braces around it are truly unchanged.
+        assert!(
+            !text.contains("-{\n"),
+            "unchanged line shown as removed: {text}"
+        );
+        assert!(
+            !text.contains("-}\n"),
+            "unchanged line shown as removed: {text}"
+        );
+    }
+
+    #[test]
+    fn applying_a_file_write_creates_parents_and_sets_the_mode() {
+        let home = scratch("apply-write");
+        let path = home.join("deep/er/hook.sh");
+        apply(&Change::WriteFile {
+            path: path.clone(),
+            before: None,
+            after: "#!/bin/sh\n".into(),
+            executable: true,
+        })
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "#!/bin/sh\n");
+        assert_eq!(
+            std::fs::read_dir(path.parent().unwrap()).unwrap().count(),
+            1,
+            "no staging file left"
+        );
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o111,
+            0o111
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn a_failing_command_is_an_error() {
+        let error = apply(&Change::Run {
+            argv: vec!["false".into()],
+        })
+        .expect_err("false exits 1");
+        assert!(error.to_string().contains("false"), "{error}");
+    }
+
+    #[test]
+    fn claude_shim_is_read_from_the_config_dir() {
+        let home = scratch("claude-shim-read");
+        let file = home.join(".claude.json");
+        assert_eq!(registered_claude_shim(&file), None);
+        std::fs::write(
+            &file,
+            r#"{"mcpServers":{"banshee":{"type":"stdio","command":"/x/banshee-mcp-shim","args":[]}}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            registered_claude_shim(&file).as_deref(),
+            Some("/x/banshee-mcp-shim")
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn plans_that_need_the_shim_refuse_without_it() {
+        let home = scratch("no-shim");
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        let mut env = env_at(&home);
+        env.shim = None;
+        let error = plan(Agent::ClaudeCode, &env).expect_err("claude needs the shim");
+        assert!(matches!(error, BansheeError::Rejected(_)), "{error:?}");
+        assert_eq!(
+            error.to_string(),
+            "banshee-mcp-shim is not beside /opt/banshee/bin/banshee; reinstall so they ship together"
+        );
+        assert!(plan(Agent::OpenCode, &env).is_err());
+        assert_eq!(plan(Agent::Pi, &env).unwrap().len(), 1);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn claude_plan_reissues_the_server_when_the_registered_command_differs() {
+        let home = scratch("claude-stale-shim");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("/old/bin/banshee-mcp-shim".into());
+        let changes = plan(Agent::ClaudeCode, &env).unwrap();
+        assert_eq!(
+            changes[0],
+            Change::Run {
+                argv: ["claude", "mcp", "remove", "--scope", "user", "banshee"]
+                    .map(String::from)
+                    .to_vec()
+            }
+        );
+        assert_eq!(
+            changes[1],
+            Change::Run {
+                argv: [
+                    "claude",
+                    "mcp",
+                    "add",
+                    "--scope",
+                    "user",
+                    "banshee",
+                    "--",
+                    "/opt/banshee/bin/banshee-mcp-shim"
+                ]
+                .map(String::from)
+                .to_vec()
+            }
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn claude_plan_repairs_a_missing_script_at_the_canonical_path() {
+        let home = scratch("claude-script-gone");
+        let mut env = env_at(&home);
+        env.on_path.push("claude");
+        env.claude_shim = Some("/opt/banshee/bin/banshee-mcp-shim".into());
+        let script_path = home.join(".claude/hooks/banshee-speak-check.sh");
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        std::fs::write(
+            home.join(".claude/settings.json"),
+            format!(
+                r#"{{"hooks":{{"Stop":[{{"hooks":[{{"type":"command","command":"bash '{}'"}}]}}]}}}}"#,
+                script_path.display()
+            ),
+        )
+        .unwrap();
+        let changes = plan(Agent::ClaudeCode, &env).unwrap();
+        match &changes[..] {
+            [
+                Change::WriteFile {
+                    path,
+                    before,
+                    after,
+                    executable,
+                },
+            ] => {
+                assert_eq!(path, &script_path);
+                assert_eq!(*before, None);
+                assert_eq!(after, &hook_script(&env.banshee));
+                assert!(executable);
+            }
+            other => panic!("{other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn opencode_plan_targets_the_jsonc_file() {
+        let home = scratch("opencode-plan");
+        std::fs::create_dir_all(home.join(".config/opencode")).unwrap();
+        let changes = plan(Agent::OpenCode, &env_at(&home)).unwrap();
+        match &changes[..] {
+            [
+                Change::WriteFile {
+                    path,
+                    before,
+                    executable,
+                    ..
+                },
+            ] => {
+                assert_eq!(path, &home.join(".config/opencode/opencode.jsonc"));
+                assert_eq!(*before, None);
+                assert!(!executable);
+            }
+            other => panic!("{other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
+    }
+}

--- a/bansheed/src/main.rs
+++ b/bansheed/src/main.rs
@@ -3,6 +3,7 @@ mod args;
 mod audio;
 mod binding;
 mod config;
+mod connect;
 mod daemon;
 mod dictation;
 mod history;
@@ -686,6 +687,12 @@ async fn main() -> Result<(), BansheeError> {
                 let log = service::install(service::Agent::Tray)?;
                 println!("The menu bar icon is running, and comes back at login.");
                 println!("Logs: {log}");
+            }
+        }
+        CommandType::Connect { agent, yes } => {
+            if let Err(error) = connect::run(agent.map(Into::into), yes) {
+                eprintln!("{error}");
+                std::process::exit(1);
             }
         }
         CommandType::Service { action } => match action {

--- a/bansheed/src/service.rs
+++ b/bansheed/src/service.rs
@@ -1,5 +1,9 @@
 // Start-at-login behind a neutral surface: launchd on macOS, systemd on Linux.
 
+use std::path::{Path, PathBuf};
+
+use banshee_common::error::BansheeError;
+
 /// What can be set to start at login. The platform arms decide what they can
 /// honour, so a new entry is one variant rather than a new pair of functions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,6 +23,27 @@ impl Agent {
     }
 }
 
+// current_exe returns the symlink, so canonicalize first or a symlinked CLI
+// searches the wrong directory.
+pub(crate) fn home_dir() -> Result<PathBuf, BansheeError> {
+    dirs::home_dir().ok_or_else(|| BansheeError::Other("home dir not found".into()))
+}
+
+pub(crate) fn sibling(exe: &Path, name: &str) -> Result<PathBuf, BansheeError> {
+    let real = std::fs::canonicalize(exe)?;
+    let found = real
+        .parent()
+        .ok_or_else(|| BansheeError::Other("banshee is not inside a directory".into()))?
+        .join(name);
+    if !found.exists() {
+        return Err(BansheeError::Other(format!(
+            "{} not found; reinstall so {name} ships beside the CLI",
+            found.display()
+        )));
+    }
+    Ok(found)
+}
+
 #[cfg(target_os = "macos")]
 mod launchd {
     use std::path::{Path, PathBuf};
@@ -26,7 +51,7 @@ mod launchd {
 
     use banshee_common::error::BansheeError;
 
-    use super::Agent;
+    use super::{Agent, home_dir, sibling};
 
     fn label(agent: Agent) -> &'static str {
         match agent {
@@ -42,10 +67,6 @@ mod launchd {
     fn agent_path(home: &Path, label: &str) -> PathBuf {
         home.join("Library/LaunchAgents")
             .join(format!("{label}.plist"))
-    }
-
-    fn home_dir() -> Result<PathBuf, BansheeError> {
-        dirs::home_dir().ok_or_else(|| BansheeError::Other("home dir not found".into()))
     }
 
     /// One plist shape for both agents. `KeepAlive` fires only on failure, so
@@ -120,23 +141,6 @@ mod launchd {
         Ok(false)
     }
 
-    // current_exe returns the symlink, so canonicalize first or a symlinked CLI
-    // searches the wrong directory.
-    fn sibling(exe: &Path, name: &str) -> Result<PathBuf, BansheeError> {
-        let real = std::fs::canonicalize(exe)?;
-        let found = real
-            .parent()
-            .ok_or_else(|| BansheeError::Other("banshee is not inside a directory".into()))?
-            .join(name);
-        if !found.exists() {
-            return Err(BansheeError::Other(format!(
-                "{} not found; reinstall so the tray ships beside the CLI",
-                found.display()
-            )));
-        }
-        Ok(found)
-    }
-
     // The daemon is this binary; the tray ships beside it, so one install
     // moves the pair together
     fn program(agent: Agent) -> Result<Vec<String>, BansheeError> {
@@ -185,56 +189,6 @@ mod launchd {
             fn getuid() -> u32;
         }
         unsafe { getuid() }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        // Builds a scratch directory holding a bundle layout for the test to use.
-        fn scratch(name: &str) -> PathBuf {
-            let dir = std::env::temp_dir().join(format!("banshee-{name}-{}", std::process::id()));
-            let _ = std::fs::remove_dir_all(&dir);
-            std::fs::create_dir_all(dir.join("Banshee.app/Contents/MacOS")).unwrap();
-            std::fs::create_dir_all(dir.join("bin")).unwrap();
-            dir
-        }
-
-        #[test]
-        fn a_sibling_resolves_through_a_symlinked_cli() {
-            let dir = scratch("sibling");
-            let real = dir.join("Banshee.app/Contents/MacOS/banshee");
-            let tray = dir.join("Banshee.app/Contents/MacOS/banshee-tray");
-            std::fs::write(&real, "").unwrap();
-            std::fs::write(&tray, "").unwrap();
-            let link = dir.join("bin/banshee");
-            std::os::unix::fs::symlink(&real, &link).unwrap();
-
-            let found = sibling(&link, "banshee-tray").unwrap();
-
-            assert_eq!(
-                std::fs::canonicalize(&found).unwrap(),
-                std::fs::canonicalize(&tray).unwrap(),
-                "the lookup must land inside the bundle, not beside the symlink"
-            );
-            let _ = std::fs::remove_dir_all(&dir);
-        }
-
-        #[test]
-        fn a_missing_sibling_names_itself() {
-            let dir = scratch("missing");
-            let real = dir.join("Banshee.app/Contents/MacOS/banshee");
-            std::fs::write(&real, "").unwrap();
-
-            let error =
-                sibling(&real, "banshee-tray").expect_err("a missing tray must not succeed");
-
-            assert!(
-                error.to_string().contains("banshee-tray"),
-                "unhelpful error: {error}"
-            );
-            let _ = std::fs::remove_dir_all(&dir);
-        }
     }
 }
 
@@ -356,3 +310,53 @@ mod unsupported {
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 pub use unsupported::{install, service_file_path, uninstall};
+
+#[cfg(test)]
+mod sibling_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // Builds a scratch directory holding a bundle layout for the test to use.
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("banshee-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("Banshee.app/Contents/MacOS")).unwrap();
+        std::fs::create_dir_all(dir.join("bin")).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_sibling_resolves_through_a_symlinked_cli() {
+        let dir = scratch("sibling");
+        let real = dir.join("Banshee.app/Contents/MacOS/banshee");
+        let tray = dir.join("Banshee.app/Contents/MacOS/banshee-tray");
+        std::fs::write(&real, "").unwrap();
+        std::fs::write(&tray, "").unwrap();
+        let link = dir.join("bin/banshee");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let found = sibling(&link, "banshee-tray").unwrap();
+
+        assert_eq!(
+            std::fs::canonicalize(&found).unwrap(),
+            std::fs::canonicalize(&tray).unwrap(),
+            "the lookup must land inside the bundle, not beside the symlink"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_sibling_names_itself() {
+        let dir = scratch("missing");
+        let real = dir.join("Banshee.app/Contents/MacOS/banshee");
+        std::fs::write(&real, "").unwrap();
+
+        let error = sibling(&real, "banshee-tray").expect_err("a missing tray must not succeed");
+
+        assert!(
+            error.to_string().contains("banshee-tray"),
+            "unhelpful error: {error}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/bansheed/src/status.rs
+++ b/bansheed/src/status.rs
@@ -167,8 +167,7 @@ fn runs(bin: &str) -> bool {
 }
 
 // Walks $PATH directly: `which` is its own package on minimal systems.
-#[cfg(all(unix, not(target_os = "macos")))]
-fn on_path(bin: &str) -> bool {
+pub(crate) fn on_path(bin: &str) -> bool {
     std::env::var_os("PATH")
         .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join(bin).is_file()))
 }

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,0 +1,47 @@
+# Claude Code
+
+`banshee-speak-check.sh` is a Stop hook. It reads the turn that is about to end
+and looks for a call to the `speak_status` or `ask_user` tool of the Banshee MCP
+server. If the turn made neither call, the hook blocks the end of the turn and
+tells the agent to speak. Every other path lets the turn end, so a broken
+assumption costs a missed reminder, not a stuck session.
+
+## Install
+
+```bash
+banshee connect claude
+```
+
+That writes the script into `$CLAUDE_CONFIG_DIR/hooks/` and registers it in
+`settings.json`, after it shows you both changes.
+
+## Install by hand
+
+Copy `banshee-speak-check.sh` into `$CLAUDE_CONFIG_DIR/hooks/` (by default
+`~/.claude/hooks/`) and make it executable. Replace `@BANSHEE_BIN@` in the script
+with the absolute path of your `banshee` binary. Then add the hook to
+`settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/Users/you/.claude/hooks/banshee-speak-check.sh'",
+            "timeout": 15,
+            "statusMessage": "Checking you spoke"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Requirement
+
+The script reads the hook payload and the transcript with `jq`. Put `jq` on your
+PATH, or the hook exits without a check.

--- a/integrations/claude-code/banshee-speak-check.sh
+++ b/integrations/claude-code/banshee-speak-check.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Stop hook: a turn does not end until its status has been spoken aloud.
+# Every exit path other than the last one lets the turn end. Blocking is the
+# exception, so a broken assumption here costs a missed reminder, not a wedged
+# session.
+set -uo pipefail
+
+payload=$(cat)
+field() { printf '%s' "$payload" | jq -r "$1 // empty" 2>/dev/null; }
+
+# Already sent back once for this turn. Blocking again never terminates.
+[ "$(field '.stop_hook_active')" = "true" ] && exit 0
+
+# PATH is not the login shell's inside a hook, so resolve the binary directly
+banshee="${BANSHEE_BIN:-@BANSHEE_BIN@}"
+[ -x "$banshee" ] || banshee=$(command -v banshee 2>/dev/null)
+# Nothing to speak through: let the turn end rather than demand the impossible
+[ -n "$banshee" ] && "$banshee" status --json 2>/dev/null | jq -e '.running == true' >/dev/null || exit 0
+
+transcript=$(field '.transcript_path')
+prompt=$(field '.prompt_id')
+[ -n "$transcript" ] && [ -f "$transcript" ] && [ -n "$prompt" ] || exit 0
+
+# Every line of a turn that carries a prompt id carries this one: the user's
+# own line and each tool result after it. So the next turn is the next id that
+# differs, not merely the next id -- most of them belong to this turn.
+start=$(grep -n "\"promptId\":\"$prompt\"" "$transcript" | head -1 | cut -d: -f1)
+[ -n "$start" ] || exit 0
+end=$(grep -n '"promptId":"' "$transcript" | grep -v "\"promptId\":\"$prompt\"" |
+  awk -F: -v s="$start" '$1 > s { print $1; exit }')
+
+if [ -n "$end" ]; then
+  turn=$(sed -n "${start},$((end - 1))p" "$transcript")
+else
+  turn=$(tail -n +"$start" "$transcript")
+fi
+
+# Matched on the tool_use block, not the raw name: the tool definitions carried
+# in the transcript spell the same names and would match a plain grep
+spoken=$(printf '%s\n' "$turn" | jq -r '
+  select(.type == "assistant")
+  | .message.content[]?
+  | select(.type == "tool_use")
+  | .name' 2>/dev/null |
+  grep -cE '^mcp__banshee__(speak_status|ask_user)$')
+
+[ "${spoken:-0}" -gt 0 ] && exit 0
+
+jq -n '{
+  decision: "block",
+  reason: ("You are about to end this turn without saying anything aloud. "
+    + "The user is working eyes-free and is not reading the screen. "
+    + "Speak your status now with the banshee speak_status tool, or ask_user "
+    + "if you need an answer from them, then finish. Keep written output for "
+    + "what must be read: code, paths, commands, tables.")
+}'

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -10,8 +10,12 @@ extra to install or configure.
 
 ## Install
 
-The extension isn't part of the `banshee` binary, so fetch it into Pi's
-extensions directory:
+```bash
+banshee connect pi
+```
+
+That writes `~/.pi/agent/extensions/banshee.ts` after showing you the change. Without the
+`banshee` CLI, fetch the file yourself:
 
 ```bash
 mkdir -p ~/.pi/agent/extensions
@@ -19,11 +23,7 @@ curl -o ~/.pi/agent/extensions/banshee.ts \
   https://raw.githubusercontent.com/yamanahlawat/banshee/main/integrations/pi/banshee.ts
 ```
 
-From a clone, `cp integrations/pi/banshee.ts ~/.pi/agent/extensions/` does the
-same thing.
-
-Restart Pi. The tools are picked up automatically; extensions in that directory
-need no registration.
+Restart Pi. Extensions in that directory need no registration.
 
 The daemon has to be running, with the models already downloaded:
 


### PR DESCRIPTION
connecting an agent used to mean editing another tool's config by hand from the readme.
`banshee connect` now does it: it detects the agent, shows the exact command or file diff,
asks once, then writes.

## what it does

- `banshee connect` lists antigravity, claude, codex, cursor, opencode and pi, each as
  installed or not, connected or not
- `banshee connect <agent> [--yes]` shows the change and waits for a `y`. the default is no
- claude code gets the mcp server (`claude mcp add`, with a `remove` first when the
  registered command differs) and the stop hook that refuses to end a turn with no spoken
  status. the hook script moves into the repo under `integrations/claude-code/`
- antigravity, cursor and opencode get their mcp entry edited in place; codex gets a
  `toml_edit` edit that keeps comments; pi gets the native extension written
- "connected" means the plan is empty. a bare `banshee-mcp-shim` counts when `PATH` resolves
  it to the same file as the shim; an absolute path counts when it canonicalizes to it
