### PR TITLE
feat: connect GitHub Copilot CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`banshee connect` wires up your coding agent.** `banshee connect antigravity`,
-  `claude`, `codex`, `cursor`, `opencode` or `pi` detects the tool, shows the exact
+  `claude`, `codex`, `copilot`, `cursor`, `opencode` or `pi` detects the tool, shows the exact
   change to its config, and writes it only after you say yes. Claude Code gets the MCP
   server and a stop hook that makes each turn end with a spoken status; the others get
   the MCP server entry, and Pi its native extension. `banshee connect` alone lists what

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ banshee connect            # which agents are installed, and which are connected
 banshee connect antigravity # Antigravity IDE, agy CLI and SDK: the MCP server in ~/.gemini/config/mcp_config.json
 banshee connect claude      # Claude Code: the MCP server and a stop hook that refuses to end a turn with no spoken status
 banshee connect codex       # Codex CLI: the MCP server in ~/.codex/config.toml
+banshee connect copilot     # GitHub Copilot CLI: the MCP server in ~/.copilot/mcp-config.json
 banshee connect cursor      # Cursor: the MCP server in ~/.cursor/mcp.json
 banshee connect opencode    # OpenCode: the MCP server
 banshee connect pi          # Pi: the native extension
@@ -198,7 +199,7 @@ banshee connect pi          # Pi: the native extension
 Each command shows the exact change to that tool's config and asks before it
 writes, then you restart the tool. The Claude Code hook needs `jq` on your
 PATH. Antigravity, Claude Code, OpenCode and Pi are verified on a real install;
-Codex and Cursor follow their published formats and wait for a report.
+Codex, Copilot and Cursor follow their published formats and wait for a report.
 
 Pi has its own extension API instead of MCP, so `banshee connect pi` installs a
 native extension that talks to the daemon directly; see
@@ -209,7 +210,7 @@ the change before it writes, and says which agents are connected.
 
 <p align="center">
   <img src="assets/agents.png" width="360"
-       alt="The Agents panel, listing Antigravity, Claude Code, OpenCode and Pi as connected, and noting that Banshee also works with Codex and Cursor.">
+       alt="The Agents panel, listing Antigravity, Claude Code, OpenCode and Pi as connected, and noting that Banshee also works with Codex, Copilot and Cursor.">
 </p>
 
 `banshee-mcp-shim` is the MCP stdio server behind this. Any other MCP host takes

--- a/bansheed/src/args.rs
+++ b/bansheed/src/args.rs
@@ -62,7 +62,7 @@ pub enum CommandType {
         #[clap(subcommand)]
         action: ServiceAction,
     },
-    /// Connect a coding agent to Banshee: Antigravity, Claude Code, Codex, Cursor, OpenCode or Pi
+    /// Connect a coding agent to Banshee: Antigravity, Claude Code, Codex, Copilot, Cursor, OpenCode or Pi
     Connect {
         /// Which agent; omit to list what is installed and connected
         agent: Option<AgentName>,
@@ -77,6 +77,7 @@ pub enum AgentName {
     Antigravity,
     Claude,
     Codex,
+    Copilot,
     Cursor,
     Opencode,
     Pi,

--- a/bansheed/src/connect.rs
+++ b/bansheed/src/connect.rs
@@ -9,16 +9,18 @@ pub enum Agent {
     Antigravity,
     ClaudeCode,
     Codex,
+    Copilot,
     Cursor,
     OpenCode,
     Pi,
 }
 
 impl Agent {
-    pub const ALL: [Agent; 6] = [
+    pub const ALL: [Agent; 7] = [
         Agent::Antigravity,
         Agent::ClaudeCode,
         Agent::Codex,
+        Agent::Copilot,
         Agent::Cursor,
         Agent::OpenCode,
         Agent::Pi,
@@ -29,6 +31,7 @@ impl Agent {
             Agent::Antigravity => "antigravity",
             Agent::ClaudeCode => "claude",
             Agent::Codex => "codex",
+            Agent::Copilot => "copilot",
             Agent::Cursor => "cursor",
             Agent::OpenCode => "opencode",
             Agent::Pi => "pi",
@@ -41,6 +44,7 @@ impl Agent {
             Agent::Antigravity => "Antigravity",
             Agent::ClaudeCode => "Claude Code",
             Agent::Codex => "Codex",
+            Agent::Copilot => "Copilot",
             Agent::Cursor => "Cursor",
             Agent::OpenCode => "OpenCode",
             Agent::Pi => "Pi",
@@ -52,6 +56,7 @@ impl Agent {
             Agent::Antigravity => Signal::OnPath("agy"),
             Agent::ClaudeCode => Signal::OnPath("claude"),
             Agent::Codex => Signal::OnPath("codex"),
+            Agent::Copilot => Signal::OnPath("copilot"),
             Agent::Cursor => Signal::HomeDir(".cursor"),
             Agent::OpenCode => Signal::HomeDir(".config/opencode"),
             Agent::Pi => Signal::HomeDir(".pi/agent"),
@@ -71,6 +76,7 @@ impl From<crate::args::AgentName> for Agent {
             crate::args::AgentName::Antigravity => Agent::Antigravity,
             crate::args::AgentName::Claude => Agent::ClaudeCode,
             crate::args::AgentName::Codex => Agent::Codex,
+            crate::args::AgentName::Copilot => Agent::Copilot,
             crate::args::AgentName::Cursor => Agent::Cursor,
             crate::args::AgentName::Opencode => Agent::OpenCode,
             crate::args::AgentName::Pi => Agent::Pi,
@@ -287,6 +293,12 @@ pub fn plan(agent: Agent, env: &Env) -> Result<Vec<Change>, BansheeError> {
                 with_codex_server(before, shim)
             })
         }
+        Agent::Copilot => {
+            let shim = require_shim(env)?;
+            rewrite(env.home.join(".copilot/mcp-config.json"), |before| {
+                with_copilot_server(before, shim)
+            })
+        }
         Agent::Cursor => {
             let shim = require_shim(env)?;
             rewrite(env.home.join(".cursor/mcp.json"), |before| {
@@ -415,6 +427,36 @@ fn with_mcp_server(
     if reaches_shim(command, shim) {
         return Ok(None);
     }
+    entry.insert(
+        "command".into(),
+        serde_json::json!(shim.display().to_string()),
+    );
+    Ok(Some(pretty_json(&root)?))
+}
+
+fn with_copilot_server(config: Option<&str>, shim: &Path) -> Result<Option<String>, BansheeError> {
+    let mut root: serde_json::Value = match config {
+        Some(text) => json5::from_str(text).map_err(|error| {
+            malformed("mcp-config.json", &format!("could not be read: {error}"))
+        })?,
+        None => serde_json::json!({}),
+    };
+    let entry = root
+        .as_object_mut()
+        .ok_or_else(|| malformed("mcp-config.json", "is not a JSON object"))?
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed("mcp-config.json", "mcpServers is not an object"))?
+        .entry("banshee")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed("mcp-config.json", "mcpServers.banshee is not an object"))?;
+    let command = entry.get("command").and_then(serde_json::Value::as_str);
+    if entry.get("type") == Some(&serde_json::json!("local")) && reaches_shim(command, shim) {
+        return Ok(None);
+    }
+    entry.insert("type".into(), serde_json::json!("local"));
     entry.insert(
         "command".into(),
         serde_json::json!(shim.display().to_string()),

--- a/bansheed/src/connect/tests.rs
+++ b/bansheed/src/connect/tests.rs
@@ -167,6 +167,12 @@ fn cursor_is_installed_when_its_dir_exists_and_the_clis_when_on_path() {
         }
     );
     assert_eq!(
+        detect(Agent::Copilot, &env),
+        Presence::NotInstalled {
+            looked_for: "copilot on PATH".into()
+        }
+    );
+    assert_eq!(
         detect(Agent::Antigravity, &env),
         Presence::NotInstalled {
             looked_for: "agy on PATH".into()
@@ -174,9 +180,11 @@ fn cursor_is_installed_when_its_dir_exists_and_the_clis_when_on_path() {
     );
     std::fs::create_dir_all(home.join(".cursor")).unwrap();
     found(&mut env, "codex");
+    found(&mut env, "copilot");
     found(&mut env, "agy");
     assert_eq!(detect(Agent::Cursor, &env), Presence::Installed);
     assert_eq!(detect(Agent::Codex, &env), Presence::Installed);
+    assert_eq!(detect(Agent::Copilot, &env), Presence::Installed);
     assert_eq!(detect(Agent::Antigravity, &env), Presence::Installed);
     let _ = std::fs::remove_dir_all(&home);
 }
@@ -229,6 +237,38 @@ fn mcp_server_errors_name_the_file() {
     let error =
         with_mcp_server(Some("[1]"), "mcp.json", Path::new(SHIM)).expect_err("not an object");
     assert!(error.to_string().starts_with("mcp.json "), "{error}");
+}
+
+#[test]
+fn copilot_server_is_added_with_local_type() {
+    let after = with_copilot_server(None, Path::new(SHIM))
+        .unwrap()
+        .expect("a change");
+    let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+    assert_eq!(
+        value,
+        serde_json::json!({ "mcpServers": { "banshee": { "type": "local", "command": SHIM } } })
+    );
+}
+
+#[test]
+fn copilot_server_updates_an_entry_without_local_type() {
+    let before = format!(r#"{{"mcpServers":{{"banshee":{{"command":"{SHIM}"}}}}}}"#);
+    let after = with_copilot_server(Some(&before), Path::new(SHIM))
+        .unwrap()
+        .expect("missing type must be fixed");
+    let value: serde_json::Value = serde_json::from_str(&after).unwrap();
+    assert_eq!(value["mcpServers"]["banshee"]["type"], "local");
+    assert_eq!(value["mcpServers"]["banshee"]["command"], SHIM);
+}
+
+#[test]
+fn copilot_server_with_local_type_and_shim_means_no_change() {
+    let before = format!(r#"{{"mcpServers":{{"banshee":{{"type":"local","command":"{SHIM}"}}}}}}"#);
+    assert_eq!(
+        with_copilot_server(Some(&before), Path::new(SHIM)).unwrap(),
+        None
+    );
 }
 
 #[test]
@@ -321,28 +361,33 @@ fn the_new_agents_plan_their_own_files_and_need_the_shim() {
     let mut env = env_at(&home);
     std::fs::create_dir_all(home.join(".cursor")).unwrap();
     found(&mut env, "codex");
+    found(&mut env, "copilot");
     found(&mut env, "agy");
     for (agent, file) in [
         (Agent::Cursor, ".cursor/mcp.json"),
         (Agent::Codex, ".codex/config.toml"),
+        (Agent::Copilot, ".copilot/mcp-config.json"),
         (Agent::Antigravity, ".gemini/config/mcp_config.json"),
     ] {
         match &plan(agent, &env).unwrap()[..] {
-            [
-                Change::WriteFile {
-                    path,
-                    before: None,
-                    executable: false,
-                    ..
-                },
-            ] => {
+            [Change::WriteFile {
+                path,
+                before: None,
+                executable: false,
+                ..
+            }] => {
                 assert_eq!(path, &home.join(file));
             }
             other => panic!("{agent:?}: {other:?}"),
         }
     }
     env.shim = None;
-    for agent in [Agent::Cursor, Agent::Codex, Agent::Antigravity] {
+    for agent in [
+        Agent::Cursor,
+        Agent::Codex,
+        Agent::Copilot,
+        Agent::Antigravity,
+    ] {
         assert!(plan(agent, &env).is_err(), "{agent:?} must need the shim");
     }
     let _ = std::fs::remove_dir_all(&home);
@@ -476,7 +521,15 @@ fn every_agent_has_a_cli_name() {
     let names: Vec<&str> = Agent::ALL.iter().map(|a| a.name()).collect();
     assert_eq!(
         names,
-        ["antigravity", "claude", "codex", "cursor", "opencode", "pi"]
+        [
+            "antigravity",
+            "claude",
+            "codex",
+            "copilot",
+            "cursor",
+            "opencode",
+            "pi"
+        ]
     );
 }
 
@@ -710,14 +763,12 @@ fn claude_plan_repairs_a_registered_script_that_is_missing() {
     )
     .unwrap();
     match &plan(Agent::ClaudeCode, &env).unwrap()[..] {
-        [
-            Change::WriteFile {
-                path,
-                before: None,
-                executable: true,
-                ..
-            },
-        ] => {
+        [Change::WriteFile {
+            path,
+            before: None,
+            executable: true,
+            ..
+        }] => {
             assert_eq!(path, &registered)
         }
         other => panic!("{other:?}"),
@@ -1167,14 +1218,12 @@ fn claude_plan_repairs_a_missing_script_at_the_canonical_path() {
     .unwrap();
     let changes = plan(Agent::ClaudeCode, &env).unwrap();
     match &changes[..] {
-        [
-            Change::WriteFile {
-                path,
-                before,
-                after,
-                executable,
-            },
-        ] => {
+        [Change::WriteFile {
+            path,
+            before,
+            after,
+            executable,
+        }] => {
             assert_eq!(path, &script_path);
             assert_eq!(*before, None);
             assert_eq!(after, &hook_script(&env.banshee));
@@ -1191,14 +1240,12 @@ fn opencode_plan_targets_the_jsonc_file() {
     std::fs::create_dir_all(home.join(".config/opencode")).unwrap();
     let changes = plan(Agent::OpenCode, &env_at(&home)).unwrap();
     match &changes[..] {
-        [
-            Change::WriteFile {
-                path,
-                before,
-                executable,
-                ..
-            },
-        ] => {
+        [Change::WriteFile {
+            path,
+            before,
+            executable,
+            ..
+        }] => {
             assert_eq!(path, &home.join(".config/opencode/opencode.jsonc"));
             assert_eq!(*before, None);
             assert!(!executable);


### PR DESCRIPTION
## What
Fixes #57. `banshee connect` now knows the GitHub Copilot CLI target.

## Fix
Adds the Copilot agent variant and routes it through the existing MCP config writer for `~/.copilot/mcp-config.json`.

## Test
Updates the existing connect detection, planning, and CLI-name tests for Copilot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Copilot as a supported AI coding agent.
  * Added Copilot support to the connection command and MCP integrations.
  * Copilot integrations now support MCP configuration and verification.
* **Documentation**
  * Updated the README and changelog with Copilot support details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->