### PR TITLE
chore: release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-26
+
 ### Fixed
 
 - **Stopping speech no longer hangs the daemon when the speaker is gone.** Disconnect a
@@ -568,7 +570,8 @@ First public release. macOS only for now; Windows and Linux support is planned.
 - Configurable VAD threshold via `config.toml` and the `banshee.configure` RPC,
   reported back through `banshee status`.
 
-[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/yamanahlawat/banshee/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/yamanahlawat/banshee/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/yamanahlawat/banshee/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/yamanahlawat/banshee/compare/v0.8.0...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "banshee"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-common"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "dirs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bansheed", "banshee-common"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 authors = ["Yaman Ahlawat"]
 license = "MIT OR Apache-2.0"

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 anyhow = "1.0.103"
 arboard = "3.6.1"
 audioadapter-buffers = "3.0.0"
-banshee-common = { version = "0.11.0", path = "../banshee-common" }
+banshee-common = { version = "0.11.1", path = "../banshee-common" }
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.17.3"
 crossbeam-channel = "0.5.16"


### PR DESCRIPTION
release 0.11.1: one fix, #63. stopping speech no longer hangs the daemon when the speaker is gone.

version `0.11.1` in both manifests and the lock, the `0.11.1` header, and the compare links.
