### PR TITLE
Develop to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-09-02
+
 ### Added
 
 - **Banshee has a window.** Choose `Open Banshee` from the menu bar to set up
@@ -676,7 +678,8 @@ First public release. macOS only for now; Windows and Linux support is planned.
 - Configurable VAD threshold via `config.toml` and the `banshee.configure` RPC,
   reported back through `banshee status`.
 
-[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/yamanahlawat/banshee/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/yamanahlawat/banshee/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/yamanahlawat/banshee/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/yamanahlawat/banshee/compare/v0.9.0...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "banshee"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "arboard",
  "audioadapter-buffers",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-app"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "banshee-common",
  "serde",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-common"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "dirs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bansheed", "banshee-common", "banshee-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 authors = ["Yaman Ahlawat"]
 license = "MIT OR Apache-2.0"

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 arboard = "3.6.1"
 audioadapter-buffers = "3.0.0"
-banshee-common = { version = "0.11.1", path = "../banshee-common" }
+banshee-common = { version = "0.12.0", path = "../banshee-common" }
 chrono = "0.4"
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.17.3"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.12.0 is now available, dated September 2, 2026.
  * Updated release comparison links for Unreleased and version 0.12.0.

* **Documentation**
  * Added the 0.12.0 release heading and corresponding changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->