### PR TITLE
The release builds only the daemon package, so the Linux builders need no GTK

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,12 @@ verify it on a real machine. `BACKLOG.md` holds what is missing or wrong today, 
    `stt.provider`. Local stays the default; the tray and `banshee status` say when text or
    audio leaves the machine; keys live in the environment or the Keychain, never in
    `config.toml`. Lands with the honest edit to the README's offline promise.
-3. Output sinks that survive a device change (the cue and Kokoro sinks still open once).
+3. The window on Linux, as an AppImage and an AUR package, built by the bundle workflow with
+   GTK and WebKit installed. The blockers band grows rows for the typers and the daemon's
+   `PATH`, and the launcher stands in for the tray. After the keys, because no Linux user has
+   asked yet and `banshee watch --waybar` already covers the live loop there. It also gives the
+   WebDriver acceptance layer its first host: `tauri-driver` runs on Linux, not on macOS.
+4. Output sinks that survive a device change (the cue and Kokoro sinks still open once).
    Measure whether spoken status dies with the earcons before designing.
 
 ## Community sized

--- a/banshee-app/Cargo.toml
+++ b/banshee-app/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+# The bundle workflow ships the window; the dist builders have no GTK for it.
+[package.metadata.dist]
+dist = false
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/bansheed/src/service.rs
+++ b/bansheed/src/service.rs
@@ -3,7 +3,6 @@
 use std::path::PathBuf;
 
 use banshee_common::error::BansheeError;
-use banshee_common::utils::sibling;
 
 /// The platform arms decide what they honour, so a new entry is a variant, not a new pair of
 /// functions.
@@ -37,7 +36,8 @@ mod launchd {
 
     use banshee_common::utils::{DAEMON_AGENT, TRAY_AGENT, launchd_target, uid};
 
-    use super::{Agent, home_dir, sibling};
+    use super::{Agent, home_dir};
+    use banshee_common::utils::sibling;
 
     fn label(agent: Agent) -> &'static str {
         match agent {
@@ -293,7 +293,7 @@ pub use unsupported::{install, service_file_path, uninstall};
 
 #[cfg(test)]
 mod sibling_tests {
-    use super::*;
+    use banshee_common::utils::sibling;
     use std::path::PathBuf;
 
     // Builds a scratch directory holding a bundle layout for the test to use.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -28,6 +28,9 @@ install-updater = false
 # The certificate is self-signed and lives in repo secrets; no Apple membership
 # is involved. Note `dist init` rewrites the comments in this file.
 macos-sign = true
+# The window crate is not a dist package, and a --workspace build would still compile
+# it; the Linux builders have no GTK for that.
+precise-builds = true
 
 # Pin Linux runners to 24.04; the ORT prebuilt needs glibc 2.38+.
 [dist.github-custom-runners]


### PR DESCRIPTION
The v0.12.0 release run failed on both Linux builders: cargo-dist built the workspace, which now holds the Tauri window, and the runners have no GTK, so `glib-sys` did not compile. Nothing was published from that run.

## what it does

- `precise-builds = true` in `dist-workspace.toml`, so dist builds `--package=banshee` instead of `--workspace`. The window crate is marked `dist = false` as well, which on its own did not change the command.
- Moves the `sibling` import in `service.rs` into the macOS module and its tests, so the Linux build compiles without a warning.
- Adds the window on Linux to the roadmap as item 3, after bring your own keys.

## decisions worth a look

- The Linux archive is unchanged from 0.11.1: `banshee`, `banshee-mcp-shim`, the `banshee-tray` stub. The window was never in it; the bundle workflow ships it for macOS.

## testing

An Ubuntu 24.04 arm64 container with the workflow's five apt libraries plus clang, running `dist build --artifacts=local --target aarch64-unknown-linux-gnu` from this tree: without `precise-builds` the `glib-sys` build script fails as on the runner; with it the build finishes and announces the archive with the three binaries, exit 0. Locally `dist build` on macOS prints `--package=banshee`. fmt and clippy clean.

## what remains

The `v0.12.0` tag points at the failed commit and moves to `main` once this lands; nothing was published from the old one.
