### PR TITLE
The bundle runner trusts its certificate, keeps the keychain open, and runs after every release

### DIFF
--- a/.github/workflows/app-bundle.yml
+++ b/.github/workflows/app-bundle.yml
@@ -6,8 +6,13 @@
 name: App bundle
 
 on:
-  release:
-    types: [published]
+  # dist calls this after it publishes the release; the release event itself never
+  # reaches another workflow when the release is published with the workflow token.
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -23,11 +28,11 @@ jobs:
     runs-on: macos-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ inputs.tag || github.ref_name }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -50,7 +55,9 @@ jobs:
           keychain="$RUNNER_TEMP/banshee.keychain-db"
           password="$(uuidgen)"
           security create-keychain -p "$password" "$keychain"
-          security set-keychain-settings -lut 900 "$keychain"
+          # No auto-lock: the builds between this step and the signing take longer than
+          # any timeout, and a locked keychain makes codesign wait for a prompt forever.
+          security set-keychain-settings "$keychain"
           security unlock-keychain -p "$password" "$keychain"
           printf '%s' "$CODESIGN_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
           security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
@@ -64,8 +71,6 @@ jobs:
           # `find-identity -v` lists only identities whose certificate is trusted, and
           # a self-signed certificate in a fresh keychain is not, so trust it here the
           # way CONTRIBUTING.md has a developer do it once in Keychain Access.
-          echo "identities before trust:"; security find-identity -p codesigning | grep -c '"' || true
-          echo "valid before trust:"; security find-identity -p codesigning -v | grep -c '"' || true
           printf '%s' "$CODESIGN_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
           openssl pkcs12 -in "$RUNNER_TEMP/cert.p12" -passin "pass:$CODESIGN_CERTIFICATE_PASSWORD" \
             -clcerts -nokeys -legacy -out "$RUNNER_TEMP/cert.pem" 2>/dev/null \
@@ -75,7 +80,6 @@ jobs:
           rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/cert.pem"
           sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
             "$RUNNER_TEMP/cert.cer"
-          echo "valid after trust:"; security find-identity -p codesigning -v | grep -c '"' || true
 
       - run: npm ci
         working-directory: banshee-app/ui

--- a/.github/workflows/app-bundle.yml
+++ b/.github/workflows/app-bundle.yml
@@ -61,6 +61,21 @@ jobs:
           # `bundle.sh` asks `security find-identity`, which reads the search list
           security list-keychain -d user -s "$keychain" \
             $(security list-keychains -d user | tr -d '"')
+          # `find-identity -v` lists only identities whose certificate is trusted, and
+          # a self-signed certificate in a fresh keychain is not, so trust it here the
+          # way CONTRIBUTING.md has a developer do it once in Keychain Access.
+          echo "identities before trust:"; security find-identity -p codesigning | grep -c '"' || true
+          echo "valid before trust:"; security find-identity -p codesigning -v | grep -c '"' || true
+          printf '%s' "$CODESIGN_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          openssl pkcs12 -in "$RUNNER_TEMP/cert.p12" -passin "pass:$CODESIGN_CERTIFICATE_PASSWORD" \
+            -clcerts -nokeys -legacy -out "$RUNNER_TEMP/cert.pem" 2>/dev/null \
+            || openssl pkcs12 -in "$RUNNER_TEMP/cert.p12" -passin "pass:$CODESIGN_CERTIFICATE_PASSWORD" \
+            -clcerts -nokeys -out "$RUNNER_TEMP/cert.pem"
+          openssl x509 -in "$RUNNER_TEMP/cert.pem" -outform DER -out "$RUNNER_TEMP/cert.cer"
+          rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/cert.pem"
+          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+            "$RUNNER_TEMP/cert.cer"
+          echo "valid after trust:"; security find-identity -p codesigning -v | grep -c '"' || true
 
       - run: npm ci
         working-directory: banshee-app/ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,3 +344,12 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
+  custom-app-bundle:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/app-bundle.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -31,6 +31,9 @@ macos-sign = true
 # The window crate is not a dist package, and a --workspace build would still compile
 # it; the Linux builders have no GTK for that.
 precise-builds = true
+# The bundle workflow listens for the release event, but a release published with the
+# workflow token raises no event another workflow can see, so dist calls it instead.
+post-announce-jobs = ["./app-bundle"]
 
 # Pin Linux runners to 24.04; the ORT prebuilt needs glibc 2.38+.
 [dist.github-custom-runners]


### PR DESCRIPTION
The first v0.12.0 bundle run failed at signing, and a second one hung for an hour; the bundle reached the release only after a hand-dispatched run of this branch.

## what it does

- Trusts the imported certificate on the runner. `bundle.sh` asks `security find-identity -v`, which lists only identities whose certificate is trusted, and a self-signed certificate in a fresh keychain is not. Measured on run 33657354625: one identity present, zero valid before the trust step, valid after it.
- Removes the keychain's auto-lock. It was set to lock after 900 s; the daemon and window builds take longer, and `codesign` then waits forever for an unlock prompt. Run 33657354625 sat in the sign step for 53 min before I cancelled it.
- `post-announce-jobs = ["./app-bundle"]` in `dist-workspace.toml`, so the release workflow calls this one after it publishes. A release published with the workflow token raises no event another workflow can see, which is why the `release: published` trigger never fired. `release.yml` is regenerated by `dist generate`; the bundle workflow gains `workflow_call` and reads the tag from `github.ref_name` when called.

## decisions worth a look

- Trust is added to the System keychain with `sudo`, the way CONTRIBUTING.md has a developer set Always Trust once. The runner is discarded after the job.

## testing

Run 33664694076 of this branch, dispatched with `tag=v0.12.0`: passed, and `Banshee.app.tar.gz` is on the release. The chained call after announce is not exercised until the next release; `dist generate` produced the job.

## what remains

The bundle for 0.12.0 came from a dispatch, not from the release run. Nothing else.
