### PR TITLE
Homebrew installs the window as a cask, and the README names one install per audience

### DIFF
--- a/.github/workflows/app-bundle.yml
+++ b/.github/workflows/app-bundle.yml
@@ -92,3 +92,26 @@ jobs:
           codesign --verify --strict --verbose=2 "$RUNNER_TEMP/check/Banshee.app"
 
       - run: gh release upload "$TAG" Banshee.app.tar.gz --clobber
+
+      # The cask is the macOS install; it names the tarball this run just uploaded.
+      - uses: actions/checkout@v6
+        with:
+          repository: yamanahlawat/homebrew-banshee
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+          persist-credentials: true
+      - name: publish the cask
+        run: |
+          set -euo pipefail
+          version="$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)"
+          [ "v${version}" = "$TAG" ] || { echo "tag $TAG is not v${version}, the version in Cargo.toml" >&2; exit 1; }
+          sha="$(shasum -a 256 Banshee.app.tar.gz | cut -d' ' -f1)"
+          mkdir -p tap/Casks
+          sed -e "s/@VERSION@/${version}/" -e "s/@SHA256@/${sha}/" packaging/banshee.cask.rb > tap/Casks/banshee.rb
+          brew style tap/Casks/banshee.rb
+          cd tap
+          git config user.name "banshee release"
+          git config user.email "release@banshee.invalid"
+          git add Casks/banshee.rb
+          # A second run for the same tag renders the same file; that is not a failure.
+          git diff --quiet --cached || { git commit -m "banshee cask ${version}" && git push; }

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,9 +20,24 @@ nothing here is ordered. `ROADMAP.md` holds what lands next.
   the checklist can name a typer the daemon cannot run. `connect` resolves an agent CLI and
   hands the child the `PATH` it searched; dictation does neither. Not reproduced: this
   machine is macOS.
+- `daemon.always_on` is parsed from `config.toml` and read nowhere, so the key does nothing and
+  the configuration page does not list it. Either a consumer or a removal, with the parse kept
+  so an old file still loads.
 - `daemon.log` carries no timestamps, so no interval in it can be measured.
 - Past eight queued utterances the oldest is dropped silently, and `speak` still answers with
   an id for it.
+
+- `banshee status` prints a check mark beside "daemon has the microphone: No microphone" when
+  no device is open. Seen on a fresh 0.12.0 install before the models were fetched. The line
+  should fail, or name the device it has.
+- `banshee status` one second after `banshee start` reports "the daemon is not running": the
+  socket is not bound yet while Whisper loads. Measured on a fresh 0.12.0 install; the same
+  command a few seconds later reports running. `start` should wait for the socket, or `status`
+  should say the daemon is starting.
+- A release published by the release workflow raises no event another workflow can see. The
+  bundle workflow's `release: published` trigger never fired for 0.12.0, and the bundle came
+  from a hand dispatch. #84 chains the bundle after announce; until it merges, a release needs
+  the dispatch by hand.
 
 ## The window
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Homebrew installs the window.** `brew install --cask
+  yamanahlawat/banshee/banshee` puts `Banshee.app` in `/Applications` and the
+  `banshee` and `banshee-mcp-shim` commands on your `PATH`, one copy of
+  everything. The cask refuses to install beside the `banshee` formula, which is
+  the same daemon without the window. The README says which path fits which
+  use, and how to uninstall each.
+
 ## [0.12.0] - 2026-09-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ can do.
 | --- | --- |
 | `banshee` (in `bansheed/`) | The daemon: audio capture, VAD, STT, hotkeys, JSON-RPC API. Also builds `banshee-mcp-shim` (`src/bin/`), the MCP stdio to daemon bridge |
 | `banshee-common` | Shared protocol types (JSON-RPC, errors, config) |
+| `banshee-app` | The desktop window: a Tauri app that is a client of the daemon's socket, shipped inside `Banshee.app` |
 
 The daemon exposes a JSON-RPC 2.0 API over a Unix socket at
 `~/.banshee/banshee.sock`. The CLI and the MCP shim are both just clients of it.

--- a/README.md
+++ b/README.md
@@ -21,16 +21,61 @@ hears "let's go with python", and writes the file. Nothing was typed.
 
 ## Install
 
-|                       | Daemon, CLI, agent voice, dictation | Desktop window |
-| --------------------- | ----------------------------------- | -------------- |
-| macOS (Apple Silicon) | yes                                 | yes            |
-| Linux (x86_64, arm64) | yes, with [setup](docs/linux.md)    | not yet        |
-| Windows               | not yet                             | not yet        |
+|                       | With the desktop window            | Terminal only                          |
+| --------------------- | ---------------------------------- | -------------------------------------- |
+| macOS (Apple Silicon) | [the cask](#macos-with-the-window) | [the formula](#macos-terminal-only)    |
+| Linux (x86_64, arm64) | not yet                            | [the formula or the installer](#linux) |
+| Windows               | not yet                            | not yet                                |
 
-Needs ~1 GB of disk for the models. Intel Macs are not supported.
+Pick one. Needs ~1 GB of disk for the models. Intel Macs are not supported.
+
+### macOS, with the window
 
 ```bash
-brew install yamanahlawat/banshee/banshee
+brew install --cask yamanahlawat/banshee/banshee
+xattr -dr com.apple.quarantine /Applications/Banshee.app
+```
+
+The second line is needed until Banshee is notarised. Homebrew marks the
+download as quarantined; a quarantined Banshee will not open, and its `banshee`
+command dies with no message.
+
+Then open Banshee from `/Applications`. It fetches the models, asks for the
+two grants and starts the daemon. The `banshee` command is on your `PATH` too.
+
+Installed the app with `curl` before? Delete `/Applications/Banshee.app` first.
+Installed the formula before? Run these first, in this order:
+
+```bash
+banshee tray --uninstall
+banshee service uninstall
+brew uninstall --formula banshee
+```
+
+Without Homebrew: download and unpack the app, which sets no quarantine flag.
+
+```bash
+curl -fsSL https://github.com/yamanahlawat/banshee/releases/latest/download/Banshee.app.tar.gz \
+  | tar -xzf - -C /Applications
+```
+
+The `banshee` command is then `/Applications/Banshee.app/Contents/MacOS/banshee`;
+link it onto your `PATH` if you want it short. No admin account? Unpack into
+`~/Applications` and read that path instead.
+
+### macOS, terminal only
+
+```bash
+brew install --formula yamanahlawat/banshee/banshee
+```
+
+The daemon, the `banshee` command and the menu bar icon. To add the window
+later, follow the switch above, then install the cask.
+
+### Linux
+
+```bash
+brew install --formula yamanahlawat/banshee/banshee
 ```
 
 Or without Homebrew:
@@ -40,39 +85,28 @@ curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/yamanahlawat/banshee/releases/latest/download/banshee-installer.sh | sh
 ```
 
-Both install the daemon, the CLI and the menu bar icon. For the desktop window,
-add the app bundle:
+The daemon and the `banshee` command. `banshee watch --waybar` feeds a status
+bar. See [docs/linux.md](docs/linux.md) for the typing tool and the service.
 
-```bash
-curl -fsSL https://github.com/yamanahlawat/banshee/releases/latest/download/Banshee.app.tar.gz \
-  | tar -xzf - -C /Applications
-```
+### From source
 
-Writing to `/Applications` needs an admin account. Without one, run
-`mkdir -p ~/Applications`, extract there instead, and read that path
-everywhere below.
+Clone the repo and run `make install`; see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-The bundle carries all four binaries, so it is a whole install on its own. Run
-`/Applications/Banshee.app/Contents/MacOS/banshee start` once, or link that
-binary onto your `PATH`.
+## Uninstall
 
-Banshee is signed but not yet notarised, so macOS refuses a copy that arrives
-carrying a quarantine flag. `curl` sets none, which is why the command above is
-a `curl`. If you download the tarball in a browser instead, clear the flag once:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/Banshee.app
-```
-
-To build it yourself, clone the repo and run `make install` (see
-[CONTRIBUTING.md](CONTRIBUTING.md)); `cargo install --path bansheed` builds the
-CLI and the daemon alone.
+- The cask: `brew uninstall --zap --cask banshee`. `--zap` also removes
+  `~/.banshee`, which holds the models, the history and `config.toml`.
+- The formula or the installer: `banshee tray --uninstall`, then
+  `banshee service uninstall`, then `brew uninstall --formula banshee` or delete
+  the binaries. Delete `~/.banshee` if you want the models and history gone too.
+- The app from `curl`: the two `banshee` commands above, then delete
+  `/Applications/Banshee.app`, and `~/.banshee` if you want.
 
 ## Set up
 
-With the app bundle installed, the desktop window does all of this for you:
-open it and it fetches the models, asks for the grants and starts the daemon.
-The steps below are the same work from a terminal.
+With the window installed, from the cask or from `curl`, open Banshee. It
+fetches the models, asks for the grants and starts the daemon. The steps below
+are the same work from a terminal.
 
 **1. Download the models** (~860 MB: Whisper, Silero VAD, Kokoro):
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,20 +17,20 @@ verify it on a real machine. `BACKLOG.md` holds what is missing or wrong today, 
 
 ## Next, maintainer
 
-1. Notarisation with an Apple Developer ID, so the `Banshee.app` bundle installs without
-   the Gatekeeper dance. Now the only thing gating every distribution channel, and the
-   window has made it the first thing a new user meets.
-2. Bring your own keys: a remote provider for TTS, then for STT, behind `tts.provider` and
+1. Bring your own keys: a remote provider for TTS, then for STT, behind `tts.provider` and
    `stt.provider`. Local stays the default; the tray and `banshee status` say when text or
    audio leaves the machine; keys live in the environment or the Keychain, never in
    `config.toml`. Lands with the honest edit to the README's offline promise.
-3. The window on Linux, as an AppImage and an AUR package, built by the bundle workflow with
+2. The window on Linux, as an AppImage and an AUR package, built by the bundle workflow with
    GTK and WebKit installed. The blockers band grows rows for the typers and the daemon's
    `PATH`, and the launcher stands in for the tray. After the keys, because no Linux user has
    asked yet and `banshee watch --waybar` already covers the live loop there. It also gives the
    WebDriver acceptance layer its first host: `tauri-driver` runs on Linux, not on macOS.
-4. Output sinks that survive a device change (the cue and Kokoro sinks still open once).
+3. Output sinks that survive a device change (the cue and Kokoro sinks still open once).
    Measure whether spoken status dies with the earcons before designing.
+4. Notarisation with an Apple Developer ID, so the bundle opens with no dialog. Last, because
+   the Homebrew cask ships with 0.12.1 and the README shows the one-time Gatekeeper step, so
+   this removes a dialog rather than a gate.
 
 ## Community sized
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,9 +140,10 @@ seconds, held or toggled, is ended by the watchdog, which returns the
 microphone and still transcribes what it heard.
 
 The key is rebindable: `banshee config set audio.hotkey F6`, then
-`banshee start`. Legal values are an F-key (`F1`–`F12`), a modifier alone
-(`RightOption`, `LeftOption`, `LeftControl`, `LeftCommand`, plus
-`RightCommand` and `Fn` on macOS), or modifiers and a key, as in `Ctrl+Alt+D`.
+`banshee start`. Legal values are an F-key (`F1`–`F12`), a modifier alone, or
+modifiers and a key, as in `Ctrl+Alt+D`. The modifiers are `RightOption`,
+`LeftOption`, `LeftControl` and `LeftCommand`, plus `RightCommand` and `Fn` on
+macOS and `RightControl` on Linux.
 A modifier bound alone still works as a modifier: `RightOption+E` types é, and
 banshee discards the accidental recording instead of transcribing it.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,11 @@ the foreground when you want to watch it work. Beyond that:
   input events silently when an Accessibility grant is stale. Remove the Banshee
   entry from **System Settings > Privacy & Security > Accessibility**, restart
   the daemon, and approve the fresh prompt.
+- **You reinstalled the app, the Accessibility row is on, and Banshee still says
+  the grant is missing.** Deleting and reinstalling `/Applications/Banshee.app`
+  leaves the old row behind, and a row that looks on does not cover the new copy.
+  Select the row, click the minus button, restart the daemon, and approve the
+  fresh prompt.
 - **Permissions granted, but Banshee keeps asking.** Grants only apply to newly
   started processes. Restart the daemon with `banshee start`.
 

--- a/packaging/banshee.cask.rb
+++ b/packaging/banshee.cask.rb
@@ -1,0 +1,43 @@
+cask "banshee" do
+  version "@VERSION@"
+  sha256 "@SHA256@"
+
+  url "https://github.com/yamanahlawat/banshee/releases/download/v#{version}/Banshee.app.tar.gz"
+  name "Banshee"
+  desc "Offline voice for coding agents, and system-wide dictation"
+  homepage "https://github.com/yamanahlawat/banshee"
+
+  depends_on macos: :ventura
+  depends_on arch: :arm64
+
+  app "Banshee.app"
+  binary "#{appdir}/Banshee.app/Contents/MacOS/banshee"
+  binary "#{appdir}/Banshee.app/Contents/MacOS/banshee-mcp-shim"
+
+  # The formula is the same daemon without the window, and two copies fight for one socket;
+  # the shim formula is an old one still in the tap. Casks can conflict only with casks.
+  preflight do
+    %w[banshee banshee-mcp-shim].each do |formula|
+      next unless (HOMEBREW_PREFIX/"Cellar"/formula).directory?
+
+      raise CaskError,
+            "the #{formula} formula is installed; run `brew uninstall #{formula}` first, then install the cask"
+    end
+  end
+
+  uninstall launchctl: [
+              "com.banshee.daemon",
+              "com.banshee.tray",
+            ],
+            quit:      "com.banshee.app"
+
+  zap trash: "~/.banshee"
+
+  caveats do
+    <<~EOS
+      Banshee is signed but not yet notarised, so macOS refuses the downloaded app
+      and kills the banshee command silently. Clear the flag once:
+        xattr -dr com.apple.quarantine #{appdir}/Banshee.app
+    EOS
+  end
+end


### PR DESCRIPTION
Following the 0.12.0 README on a Mac installed the daemon twice, once from Homebrew and once inside the app, which put two rows in Accessibility and two copies on one socket. Homebrew can install the app itself, as a cask, so one path gives one copy of everything.

## what it does

- `packaging/banshee.cask.rb` is the cask: the app, `banshee` and `banshee-mcp-shim` on `PATH`, a refusal when the `banshee` or old `banshee-mcp-shim` formula is installed, launch agents removed on uninstall, `--zap` removes `~/.banshee`.
- The bundle workflow renders it after uploading the tarball, with the version from `Cargo.toml` (refused if it differs from the tag) and the tarball's sha256, runs `brew style`, and commits `Casks/banshee.rb` to the tap. A rerun for the same tag commits nothing.
- The README Install section is a table with one command per audience: the cask for a Mac with the window, the formula for terminal-only Mac and for Linux, `curl | tar` and the installer script without Homebrew. It gains an Uninstall section and the switch from formula to cask, in order.
- Troubleshooting covers a reinstalled app whose Accessibility row looks on and covers nothing. CONTRIBUTING lists the window crate. The modifier list names `RightControl` on Linux.
- Notarisation moves last on the roadmap; the backlog carries the install-test findings, the microphone status line, and the dead `daemon.always_on` key.

## decisions worth a look

- Casks cannot conflict with formulae (Homebrew 5.1 removed it), so the one-install rule is a `preflight` that raises when `Cellar/banshee` exists. Tested locally: with the formula installed the cask refuses with that sentence; after `brew uninstall banshee` it installs and links both binaries.
- Homebrew 6 has no `--no-quarantine`, and a quarantined copy kills the `banshee` command with no message (exit 137), so the README's macOS command is two lines, the second being `xattr -dr`.
- Nothing is seeded in the tap by hand. The first cask lands when 0.12.1 is tagged, so the README's cask command works from that release onward. Merge #84 first: it is what makes the release run call this workflow.

## testing

Rendered cask: `brew style` clean, `brew audit --cask --online` clean. Workflow files parse; the new step passes `bash -n`. Local install cycle on this Mac: refusal beside the formula, install after the formula's removal, one Accessibility row, daemon running from the app. README links and anchors resolve. Two rounds of `/code-review`; findings fixed.

## what remains

The chained call and the cask commit run for the first time on 0.12.1. `daemon.always_on` and the microphone status line are recorded, not fixed.
