### PR TITLE
Develop to main

### DIFF
--- a/.github/workflows/app-bundle.yml
+++ b/.github/workflows/app-bundle.yml
@@ -6,8 +6,13 @@
 name: App bundle
 
 on:
-  release:
-    types: [published]
+  # dist calls this after it publishes the release; the release event itself never
+  # reaches another workflow when the release is published with the workflow token.
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -23,11 +28,11 @@ jobs:
     runs-on: macos-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ inputs.tag || github.ref_name }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -50,7 +55,9 @@ jobs:
           keychain="$RUNNER_TEMP/banshee.keychain-db"
           password="$(uuidgen)"
           security create-keychain -p "$password" "$keychain"
-          security set-keychain-settings -lut 900 "$keychain"
+          # No auto-lock: the builds between this step and the signing take longer than
+          # any timeout, and a locked keychain makes codesign wait for a prompt forever.
+          security set-keychain-settings "$keychain"
           security unlock-keychain -p "$password" "$keychain"
           printf '%s' "$CODESIGN_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
           security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
@@ -64,8 +71,6 @@ jobs:
           # `find-identity -v` lists only identities whose certificate is trusted, and
           # a self-signed certificate in a fresh keychain is not, so trust it here the
           # way CONTRIBUTING.md has a developer do it once in Keychain Access.
-          echo "identities before trust:"; security find-identity -p codesigning | grep -c '"' || true
-          echo "valid before trust:"; security find-identity -p codesigning -v | grep -c '"' || true
           printf '%s' "$CODESIGN_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
           openssl pkcs12 -in "$RUNNER_TEMP/cert.p12" -passin "pass:$CODESIGN_CERTIFICATE_PASSWORD" \
             -clcerts -nokeys -legacy -out "$RUNNER_TEMP/cert.pem" 2>/dev/null \
@@ -75,7 +80,6 @@ jobs:
           rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/cert.pem"
           sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
             "$RUNNER_TEMP/cert.cer"
-          echo "valid after trust:"; security find-identity -p codesigning -v | grep -c '"' || true
 
       - run: npm ci
         working-directory: banshee-app/ui

--- a/.github/workflows/app-bundle.yml
+++ b/.github/workflows/app-bundle.yml
@@ -61,6 +61,21 @@ jobs:
           # `bundle.sh` asks `security find-identity`, which reads the search list
           security list-keychain -d user -s "$keychain" \
             $(security list-keychains -d user | tr -d '"')
+          # `find-identity -v` lists only identities whose certificate is trusted, and
+          # a self-signed certificate in a fresh keychain is not, so trust it here the
+          # way CONTRIBUTING.md has a developer do it once in Keychain Access.
+          echo "identities before trust:"; security find-identity -p codesigning | grep -c '"' || true
+          echo "valid before trust:"; security find-identity -p codesigning -v | grep -c '"' || true
+          printf '%s' "$CODESIGN_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          openssl pkcs12 -in "$RUNNER_TEMP/cert.p12" -passin "pass:$CODESIGN_CERTIFICATE_PASSWORD" \
+            -clcerts -nokeys -legacy -out "$RUNNER_TEMP/cert.pem" 2>/dev/null \
+            || openssl pkcs12 -in "$RUNNER_TEMP/cert.p12" -passin "pass:$CODESIGN_CERTIFICATE_PASSWORD" \
+            -clcerts -nokeys -out "$RUNNER_TEMP/cert.pem"
+          openssl x509 -in "$RUNNER_TEMP/cert.pem" -outform DER -out "$RUNNER_TEMP/cert.cer"
+          rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/cert.pem"
+          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+            "$RUNNER_TEMP/cert.cer"
+          echo "valid after trust:"; security find-identity -p codesigning -v | grep -c '"' || true
 
       - run: npm ci
         working-directory: banshee-app/ui

--- a/.github/workflows/app-bundle.yml
+++ b/.github/workflows/app-bundle.yml
@@ -92,3 +92,26 @@ jobs:
           codesign --verify --strict --verbose=2 "$RUNNER_TEMP/check/Banshee.app"
 
       - run: gh release upload "$TAG" Banshee.app.tar.gz --clobber
+
+      # The cask is the macOS install; it names the tarball this run just uploaded.
+      - uses: actions/checkout@v6
+        with:
+          repository: yamanahlawat/homebrew-banshee
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+          persist-credentials: true
+      - name: publish the cask
+        run: |
+          set -euo pipefail
+          version="$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)"
+          [ "v${version}" = "$TAG" ] || { echo "tag $TAG is not v${version}, the version in Cargo.toml" >&2; exit 1; }
+          sha="$(shasum -a 256 Banshee.app.tar.gz | cut -d' ' -f1)"
+          mkdir -p tap/Casks
+          sed -e "s/@VERSION@/${version}/" -e "s/@SHA256@/${sha}/" packaging/banshee.cask.rb > tap/Casks/banshee.rb
+          brew style tap/Casks/banshee.rb
+          cd tap
+          git config user.name "banshee release"
+          git config user.email "release@banshee.invalid"
+          git add Casks/banshee.rb
+          # A second run for the same tag renders the same file; that is not a failure.
+          git diff --quiet --cached || { git commit -m "banshee cask ${version}" && git push; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,3 +344,12 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
+  custom-app-bundle:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/app-bundle.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,9 +20,24 @@ nothing here is ordered. `ROADMAP.md` holds what lands next.
   the checklist can name a typer the daemon cannot run. `connect` resolves an agent CLI and
   hands the child the `PATH` it searched; dictation does neither. Not reproduced: this
   machine is macOS.
+- `daemon.always_on` is parsed from `config.toml` and read nowhere, so the key does nothing and
+  the configuration page does not list it. Either a consumer or a removal, with the parse kept
+  so an old file still loads.
 - `daemon.log` carries no timestamps, so no interval in it can be measured.
 - Past eight queued utterances the oldest is dropped silently, and `speak` still answers with
   an id for it.
+
+- `banshee status` prints a check mark beside "daemon has the microphone: No microphone" when
+  no device is open. Seen on a fresh 0.12.0 install before the models were fetched. The line
+  should fail, or name the device it has.
+- `banshee status` one second after `banshee start` reports "the daemon is not running": the
+  socket is not bound yet while Whisper loads. Measured on a fresh 0.12.0 install; the same
+  command a few seconds later reports running. `start` should wait for the socket, or `status`
+  should say the daemon is starting.
+- A release published by the release workflow raises no event another workflow can see. The
+  bundle workflow's `release: published` trigger never fired for 0.12.0, and the bundle came
+  from a hand dispatch. #84 chains the bundle after announce; until it merges, a release needs
+  the dispatch by hand.
 
 ## The window
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Homebrew installs the window.** `brew install --cask
+  yamanahlawat/banshee/banshee` puts `Banshee.app` in `/Applications` and the
+  `banshee` and `banshee-mcp-shim` commands on your `PATH`, one copy of
+  everything. The cask refuses to install beside the `banshee` formula, which is
+  the same daemon without the window. The README says which path fits which
+  use, and how to uninstall each.
+
 ## [0.12.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-03
+
 ### Added
 
 - **Homebrew installs the window.** `brew install --cask
@@ -687,7 +689,8 @@ First public release. macOS only for now; Windows and Linux support is planned.
 - Configurable VAD threshold via `config.toml` and the `banshee.configure` RPC,
   reported back through `banshee status`.
 
-[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/yamanahlawat/banshee/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/yamanahlawat/banshee/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/yamanahlawat/banshee/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/yamanahlawat/banshee/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Homebrew installs the window.** `brew install --cask
   yamanahlawat/banshee/banshee` puts `Banshee.app` in `/Applications` and the
   `banshee` and `banshee-mcp-shim` commands on your `PATH`, one copy of
-  everything. The cask refuses to install beside the `banshee` formula, which is
-  the same daemon without the window. The README says which path fits which
-  use, and how to uninstall each.
+  everything. Until Banshee is notarised, run
+  `xattr -dr com.apple.quarantine /Applications/Banshee.app` once after it, or
+  macOS refuses the app and kills the command silently. The cask refuses to
+  install beside the `banshee` formula, which is the same daemon without the
+  window. The README says which path fits which use, and how to uninstall each.
 
 ## [0.12.0] - 2026-09-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ can do.
 | --- | --- |
 | `banshee` (in `bansheed/`) | The daemon: audio capture, VAD, STT, hotkeys, JSON-RPC API. Also builds `banshee-mcp-shim` (`src/bin/`), the MCP stdio to daemon bridge |
 | `banshee-common` | Shared protocol types (JSON-RPC, errors, config) |
+| `banshee-app` | The desktop window: a Tauri app that is a client of the daemon's socket, shipped inside `Banshee.app` |
 
 The daemon exposes a JSON-RPC 2.0 API over a Unix socket at
 `~/.banshee/banshee.sock`. The CLI and the MCP shim are both just clients of it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "banshee"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "audioadapter-buffers",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-app"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "banshee-common",
  "serde",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-common"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "dirs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bansheed", "banshee-common", "banshee-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 authors = ["Yaman Ahlawat"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -21,16 +21,61 @@ hears "let's go with python", and writes the file. Nothing was typed.
 
 ## Install
 
-|                       | Daemon, CLI, agent voice, dictation | Desktop window |
-| --------------------- | ----------------------------------- | -------------- |
-| macOS (Apple Silicon) | yes                                 | yes            |
-| Linux (x86_64, arm64) | yes, with [setup](docs/linux.md)    | not yet        |
-| Windows               | not yet                             | not yet        |
+|                       | With the desktop window            | Terminal only                          |
+| --------------------- | ---------------------------------- | -------------------------------------- |
+| macOS (Apple Silicon) | [the cask](#macos-with-the-window) | [the formula](#macos-terminal-only)    |
+| Linux (x86_64, arm64) | not yet                            | [the formula or the installer](#linux) |
+| Windows               | not yet                            | not yet                                |
 
-Needs ~1 GB of disk for the models. Intel Macs are not supported.
+Pick one. Needs ~1 GB of disk for the models. Intel Macs are not supported.
+
+### macOS, with the window
 
 ```bash
-brew install yamanahlawat/banshee/banshee
+brew install --cask yamanahlawat/banshee/banshee
+xattr -dr com.apple.quarantine /Applications/Banshee.app
+```
+
+The second line is needed until Banshee is notarised. Homebrew marks the
+download as quarantined; a quarantined Banshee will not open, and its `banshee`
+command dies with no message.
+
+Then open Banshee from `/Applications`. It fetches the models, asks for the
+two grants and starts the daemon. The `banshee` command is on your `PATH` too.
+
+Installed the app with `curl` before? Delete `/Applications/Banshee.app` first.
+Installed the formula before? Run these first, in this order:
+
+```bash
+banshee tray --uninstall
+banshee service uninstall
+brew uninstall --formula banshee
+```
+
+Without Homebrew: download and unpack the app, which sets no quarantine flag.
+
+```bash
+curl -fsSL https://github.com/yamanahlawat/banshee/releases/latest/download/Banshee.app.tar.gz \
+  | tar -xzf - -C /Applications
+```
+
+The `banshee` command is then `/Applications/Banshee.app/Contents/MacOS/banshee`;
+link it onto your `PATH` if you want it short. No admin account? Unpack into
+`~/Applications` and read that path instead.
+
+### macOS, terminal only
+
+```bash
+brew install --formula yamanahlawat/banshee/banshee
+```
+
+The daemon, the `banshee` command and the menu bar icon. To add the window
+later, follow the switch above, then install the cask.
+
+### Linux
+
+```bash
+brew install --formula yamanahlawat/banshee/banshee
 ```
 
 Or without Homebrew:
@@ -40,39 +85,28 @@ curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/yamanahlawat/banshee/releases/latest/download/banshee-installer.sh | sh
 ```
 
-Both install the daemon, the CLI and the menu bar icon. For the desktop window,
-add the app bundle:
+The daemon and the `banshee` command. `banshee watch --waybar` feeds a status
+bar. See [docs/linux.md](docs/linux.md) for the typing tool and the service.
 
-```bash
-curl -fsSL https://github.com/yamanahlawat/banshee/releases/latest/download/Banshee.app.tar.gz \
-  | tar -xzf - -C /Applications
-```
+### From source
 
-Writing to `/Applications` needs an admin account. Without one, run
-`mkdir -p ~/Applications`, extract there instead, and read that path
-everywhere below.
+Clone the repo and run `make install`; see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-The bundle carries all four binaries, so it is a whole install on its own. Run
-`/Applications/Banshee.app/Contents/MacOS/banshee start` once, or link that
-binary onto your `PATH`.
+## Uninstall
 
-Banshee is signed but not yet notarised, so macOS refuses a copy that arrives
-carrying a quarantine flag. `curl` sets none, which is why the command above is
-a `curl`. If you download the tarball in a browser instead, clear the flag once:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/Banshee.app
-```
-
-To build it yourself, clone the repo and run `make install` (see
-[CONTRIBUTING.md](CONTRIBUTING.md)); `cargo install --path bansheed` builds the
-CLI and the daemon alone.
+- The cask: `brew uninstall --zap --cask banshee`. `--zap` also removes
+  `~/.banshee`, which holds the models, the history and `config.toml`.
+- The formula or the installer: `banshee tray --uninstall`, then
+  `banshee service uninstall`, then `brew uninstall --formula banshee` or delete
+  the binaries. Delete `~/.banshee` if you want the models and history gone too.
+- The app from `curl`: the two `banshee` commands above, then delete
+  `/Applications/Banshee.app`, and `~/.banshee` if you want.
 
 ## Set up
 
-With the app bundle installed, the desktop window does all of this for you:
-open it and it fetches the models, asks for the grants and starts the daemon.
-The steps below are the same work from a terminal.
+With the window installed, from the cask or from `curl`, open Banshee. It
+fetches the models, asks for the grants and starts the daemon. The steps below
+are the same work from a terminal.
 
 **1. Download the models** (~860 MB: Whisper, Silero VAD, Kokoro):
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,20 +17,20 @@ verify it on a real machine. `BACKLOG.md` holds what is missing or wrong today, 
 
 ## Next, maintainer
 
-1. Notarisation with an Apple Developer ID, so the `Banshee.app` bundle installs without
-   the Gatekeeper dance. Now the only thing gating every distribution channel, and the
-   window has made it the first thing a new user meets.
-2. Bring your own keys: a remote provider for TTS, then for STT, behind `tts.provider` and
+1. Bring your own keys: a remote provider for TTS, then for STT, behind `tts.provider` and
    `stt.provider`. Local stays the default; the tray and `banshee status` say when text or
    audio leaves the machine; keys live in the environment or the Keychain, never in
    `config.toml`. Lands with the honest edit to the README's offline promise.
-3. The window on Linux, as an AppImage and an AUR package, built by the bundle workflow with
+2. The window on Linux, as an AppImage and an AUR package, built by the bundle workflow with
    GTK and WebKit installed. The blockers band grows rows for the typers and the daemon's
    `PATH`, and the launcher stands in for the tray. After the keys, because no Linux user has
    asked yet and `banshee watch --waybar` already covers the live loop there. It also gives the
    WebDriver acceptance layer its first host: `tauri-driver` runs on Linux, not on macOS.
-4. Output sinks that survive a device change (the cue and Kokoro sinks still open once).
+3. Output sinks that survive a device change (the cue and Kokoro sinks still open once).
    Measure whether spoken status dies with the earcons before designing.
+4. Notarisation with an Apple Developer ID, so the bundle opens with no dialog. Last, because
+   the Homebrew cask ships with 0.12.1 and the README shows the one-time Gatekeeper step, so
+   this removes a dialog rather than a gate.
 
 ## Community sized
 

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 arboard = "3.6.1"
 audioadapter-buffers = "3.0.0"
-banshee-common = { version = "0.12.0", path = "../banshee-common" }
+banshee-common = { version = "0.12.1", path = "../banshee-common" }
 chrono = "0.4"
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.17.3"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -31,6 +31,9 @@ macos-sign = true
 # The window crate is not a dist package, and a --workspace build would still compile
 # it; the Linux builders have no GTK for that.
 precise-builds = true
+# The bundle workflow listens for the release event, but a release published with the
+# workflow token raises no event another workflow can see, so dist calls it instead.
+post-announce-jobs = ["./app-bundle"]
 
 # Pin Linux runners to 24.04; the ORT prebuilt needs glibc 2.38+.
 [dist.github-custom-runners]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,9 +140,10 @@ seconds, held or toggled, is ended by the watchdog, which returns the
 microphone and still transcribes what it heard.
 
 The key is rebindable: `banshee config set audio.hotkey F6`, then
-`banshee start`. Legal values are an F-key (`F1`–`F12`), a modifier alone
-(`RightOption`, `LeftOption`, `LeftControl`, `LeftCommand`, plus
-`RightCommand` and `Fn` on macOS), or modifiers and a key, as in `Ctrl+Alt+D`.
+`banshee start`. Legal values are an F-key (`F1`–`F12`), a modifier alone, or
+modifiers and a key, as in `Ctrl+Alt+D`. The modifiers are `RightOption`,
+`LeftOption`, `LeftControl` and `LeftCommand`, plus `RightCommand` and `Fn` on
+macOS and `RightControl` on Linux.
 A modifier bound alone still works as a modifier: `RightOption+E` types é, and
 banshee discards the accidental recording instead of transcribing it.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,11 @@ the foreground when you want to watch it work. Beyond that:
   input events silently when an Accessibility grant is stale. Remove the Banshee
   entry from **System Settings > Privacy & Security > Accessibility**, restart
   the daemon, and approve the fresh prompt.
+- **You reinstalled the app, the Accessibility row is on, and Banshee still says
+  the grant is missing.** Deleting and reinstalling `/Applications/Banshee.app`
+  leaves the old row behind, and a row that looks on does not cover the new copy.
+  Select the row, click the minus button, restart the daemon, and approve the
+  fresh prompt.
 - **Permissions granted, but Banshee keeps asking.** Grants only apply to newly
   started processes. Restart the daemon with `banshee start`.
 

--- a/packaging/banshee.cask.rb
+++ b/packaging/banshee.cask.rb
@@ -1,0 +1,43 @@
+cask "banshee" do
+  version "@VERSION@"
+  sha256 "@SHA256@"
+
+  url "https://github.com/yamanahlawat/banshee/releases/download/v#{version}/Banshee.app.tar.gz"
+  name "Banshee"
+  desc "Offline voice for coding agents, and system-wide dictation"
+  homepage "https://github.com/yamanahlawat/banshee"
+
+  depends_on macos: :ventura
+  depends_on arch: :arm64
+
+  app "Banshee.app"
+  binary "#{appdir}/Banshee.app/Contents/MacOS/banshee"
+  binary "#{appdir}/Banshee.app/Contents/MacOS/banshee-mcp-shim"
+
+  # The formula is the same daemon without the window, and two copies fight for one socket;
+  # the shim formula is an old one still in the tap. Casks can conflict only with casks.
+  preflight do
+    %w[banshee banshee-mcp-shim].each do |formula|
+      next unless (HOMEBREW_PREFIX/"Cellar"/formula).directory?
+
+      raise CaskError,
+            "the #{formula} formula is installed; run `brew uninstall #{formula}` first, then install the cask"
+    end
+  end
+
+  uninstall launchctl: [
+              "com.banshee.daemon",
+              "com.banshee.tray",
+            ],
+            quit:      "com.banshee.app"
+
+  zap trash: "~/.banshee"
+
+  caveats do
+    <<~EOS
+      Banshee is signed but not yet notarised, so macOS refuses the downloaded app
+      and kills the banshee command silently. Clear the flag once:
+        xattr -dr com.apple.quarantine #{appdir}/Banshee.app
+    EOS
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew cask support for installing Banshee.app and its command-line tools on macOS.
  * Release publishing now automatically updates the Homebrew cask with the latest version and checksum.

* **Documentation**
  * Expanded installation guidance for macOS, Linux, Homebrew, upgrades, and removal.
  * Added guidance for macOS Accessibility permissions after reinstalling.
  * Clarified Linux hotkey modifiers and modifier-only bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->