### PR TITLE
Release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-03
+
 ### Added
 
 - **Homebrew installs the window.** `brew install --cask
@@ -687,7 +689,8 @@ First public release. macOS only for now; Windows and Linux support is planned.
 - Configurable VAD threshold via `config.toml` and the `banshee.configure` RPC,
   reported back through `banshee status`.
 
-[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/yamanahlawat/banshee/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/yamanahlawat/banshee/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/yamanahlawat/banshee/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/yamanahlawat/banshee/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Homebrew installs the window.** `brew install --cask
   yamanahlawat/banshee/banshee` puts `Banshee.app` in `/Applications` and the
   `banshee` and `banshee-mcp-shim` commands on your `PATH`, one copy of
-  everything. The cask refuses to install beside the `banshee` formula, which is
-  the same daemon without the window. The README says which path fits which
-  use, and how to uninstall each.
+  everything. Until Banshee is notarised, run
+  `xattr -dr com.apple.quarantine /Applications/Banshee.app` once after it, or
+  macOS refuses the app and kills the command silently. The cask refuses to
+  install beside the `banshee` formula, which is the same daemon without the
+  window. The README says which path fits which use, and how to uninstall each.
 
 ## [0.12.0] - 2026-09-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "banshee"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "audioadapter-buffers",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-app"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "banshee-common",
  "serde",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-common"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "dirs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bansheed", "banshee-common", "banshee-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 authors = ["Yaman Ahlawat"]
 license = "MIT OR Apache-2.0"

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 arboard = "3.6.1"
 audioadapter-buffers = "3.0.0"
-banshee-common = { version = "0.12.0", path = "../banshee-common" }
+banshee-common = { version = "0.12.1", path = "../banshee-common" }
 chrono = "0.4"
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.17.3"


### PR DESCRIPTION
Version 0.12.1 in the workspace, the banshee-common requirement and the lockfile; the dated heading and compare links in CHANGELOG.md. The first release whose run calls the bundle workflow itself and writes the cask to the tap. After the merge: develop to main, then the v0.12.1 tag.