### PR TITLE
feat: the window runs on linux and the suite passes there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
-      # The VAD tests exercise the real Silero model (2 MB), same source as banshee setup
+      # The VAD tests exercise the real Silero model (2 MB), same source as banshee
+      # setup. Pinned to a commit and checked: `master` can change the test input
+      # without a change in this repository.
       - run: |
           mkdir -p ~/.banshee/models
-          curl -fsSL -o ~/.banshee/models/silero_vad.onnx https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
+          curl -fsSL -o ~/.banshee/models/silero_vad.onnx \
+            https://github.com/snakers4/silero-vad/raw/bfdc0193023f121ea5b3cc7b176dbed570a68a59/src/silero_vad/data/silero_vad.onnx
+          echo "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3  $HOME/.banshee/models/silero_vad.onnx" | shasum -a 256 -c -
       - run: cargo test
 
   # The window's suite is the only check on the Svelte half, including the
@@ -63,6 +67,35 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev libx11-dev libxtst-dev libxi-dev libxdo-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      # The window is a macOS app bundle. Building it here would need
-      # webkit2gtk and soup, which this job has no reason to install.
-      - run: cargo check --workspace --all-targets --exclude banshee-app
+      # The same pinned model the macos job checks; see the reason there.
+      - run: |
+          mkdir -p ~/.banshee/models
+          curl -fsSL -o ~/.banshee/models/silero_vad.onnx \
+            https://github.com/snakers4/silero-vad/raw/bfdc0193023f121ea5b3cc7b176dbed570a68a59/src/silero_vad/data/silero_vad.onnx
+          echo "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3  $HOME/.banshee/models/silero_vad.onnx" | sha256sum -c -
+      # The window builds in `linux-window`, which carries the WebKitGTK stack.
+      # This job runs the daemon's own suite, which no job ran on Linux before.
+      - run: cargo test --workspace --exclude banshee-app
+
+  # The window on Linux. Split from `linux` so that job stays fast: only this
+  # one pays for the WebKitGTK stack and a frontend build.
+  linux-window:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: banshee-app/ui/package-lock.json
+      # tauri-build embeds ui/dist, so the frontend builds first or the window
+      # points at the dev server.
+      - run: npm ci && npm run build
+        working-directory: banshee-app/ui
+      - run: cargo clippy -p banshee-app --all-targets -- -D warnings
+      - run: cargo test -p banshee-app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The desktop window now builds and installs on Linux.** Run `make
+  install-window` from a source clone to build it; it needs GTK, WebKitGTK
+  and Node 22. The install adds a desktop entry and icons, so your launcher
+  finds Banshee. There is still no tray icon on Linux.
+
 ### Fixed
+
+- **The window's Find hint names a key Linux keyboards have.** The record's
+  header said `⌘F`, the macOS Command glyph, on every platform. It now says
+  `Ctrl+F` off macOS. The shortcut itself always accepted both.
 
 - **The `ask_user` tool now says why it exists.** Its description tells the agent
   you cannot see the screen, so a question written as text or put in an on-screen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,19 +17,50 @@ The daemon exposes a JSON-RPC 2.0 API over a Unix socket at
 
 ## Building
 
-You need stable Rust ([rustup](https://rustup.rs)) and, for now, macOS.
+You need stable Rust ([rustup](https://rustup.rs)).
+
+`banshee-app` (the desktop window) is a Tauri app that needs GTK and
+webkit2gtk. A plain `cargo build` builds the whole workspace, so it fails on a
+Linux machine without those libraries. See
+[docs/linux.md](docs/linux.md) for the package names.
+
+On macOS:
 
 ```bash
 git clone https://github.com/yamanahlawat/banshee.git
 cd banshee
-cargo build    # Metal + CoreML acceleration for Whisper enabled automatically on macOS
+cargo build    # Metal + CoreML acceleration for Whisper enabled automatically
 ```
+
+On Linux, exclude `banshee-app`:
+
+```bash
+git clone https://github.com/yamanahlawat/banshee.git
+cd banshee
+cargo build --release --workspace --exclude banshee-app
+```
+
+This produces `target/release/banshee` and `target/release/banshee-mcp-shim`.
+`banshee-tray` also builds, but it exits immediately and points you at
+`banshee watch --waybar`. See [docs/linux.md](docs/linux.md). An `nvidia`
+feature adds CUDA acceleration: add `--features nvidia`.
+
+To also link the binaries onto your `PATH` and register the `systemd --user`
+service, use `make install` instead. It carries on when no systemd user bus
+answers. See "Installing on Linux" below.
 
 Before opening a PR, make sure both of these pass:
 
 ```bash
 cargo test
 cargo clippy --all-targets -- -D warnings
+```
+
+On Linux, exclude `banshee-app` from both, since it needs GTK and WebKitGTK:
+
+```bash
+cargo test --workspace --exclude banshee-app
+cargo clippy --workspace --all-targets --exclude banshee-app -- -D warnings
 ```
 
 ## Running your build
@@ -77,6 +108,25 @@ asks you to grant Accessibility once more. A grant only applies to a freshly
 started process, so expect to approve the prompt, run `banshee start` again,
 and repeat until the hotkey earcon plays. After that, the signature never
 changes and the grant sticks.
+
+## Installing on Linux
+
+```bash
+make install
+```
+
+Builds `banshee` and `banshee-mcp-shim` (release, `banshee-app` excluded),
+symlinks both into `~/.local/bin` (override with `BIN_DIR=...`), and runs
+`banshee start`. That registers and (re)starts a `systemd --user` unit. See
+`bansheed/src/service.rs`. A machine with no systemd user bus fails that step.
+The install still finishes, and it names `banshee serve` to start the daemon
+yourself. Re-running `make install` after a change rebuilds and restarts the
+service.
+
+`make install-window` depends on `install`, so it builds and installs the
+daemon, the CLI and the desktop window together. See
+[docs/linux.md](docs/linux.md) for what it needs. There is no signing step.
+There is no tray icon yet. Run `banshee watch --waybar` instead.
 
 ## Submitting changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,31 @@
-# Install Banshee as a signed app bundle so macOS draws its icon, and so TCC
-# grants survive rebuilds.
-# One-time setup: Keychain Access > Certificate Assistant > Create a Certificate,
-# name "banshee-dev", type "Code Signing", self-signed.
-# Needs: a Rust toolchain, `cargo install tauri-cli`, and Node 22. The Tauri
-# build runs `npm run build` in banshee-app/ui, so run `npm ci` there first.
+# Install Banshee, one target that branches by OS.
+#
+# macOS: a signed app bundle, so macOS draws its icon and TCC grants survive
+# rebuilds. One-time setup: Keychain Access > Certificate Assistant > Create
+# a Certificate, name "banshee-dev", type "Code Signing", self-signed. Needs:
+# a Rust toolchain, `cargo install tauri-cli`, and Node 22. The Tauri build
+# runs `npm run build` in banshee-app/ui, so run `npm ci` there first.
 # /Applications needs an admin account; set APP_DIR=$HOME/Applications
 # without one.
+#
+# Linux: `install` builds and installs the daemon and the CLI. No signing, no
+# bundle: build, symlink onto PATH, and register+start the systemd --user
+# service. `install-window` adds the desktop window. It needs GTK, WebKitGTK
+# and Node.
+UNAME_S := $(shell uname -s)
+
 IDENTITY ?= banshee-dev
 APP_DIR ?= /Applications
 APP := $(APP_DIR)/Banshee.app
-BIN_DIR ?= $(HOME)/.cargo/bin
 BANSHEE := $(APP)/Contents/MacOS/banshee
 VERSION := $(shell grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
 
 .PHONY: install
+
+ifeq ($(UNAME_S),Darwin)
+
+BIN_DIR ?= $(HOME)/.cargo/bin
+
 install:
 	cargo build --release --workspace --exclude banshee-app
 	# Last, and never followed by a plain `cargo build`: that rebuilds the app
@@ -26,3 +38,39 @@ install:
 	"$(BANSHEE)" start
 	"$(BANSHEE)" tray
 	rm -f "$(BIN_DIR)/banshee-tray"
+
+else
+
+# ~/.local/bin, not ~/.cargo/bin: it's what a `systemd --user` service and
+# non-interactive shells see, and ~/.cargo/bin often isn't.
+BIN_DIR ?= $(HOME)/.local/bin
+DESKTOP_DIR ?= $(HOME)/.local/share/applications
+ICON_DIR ?= $(HOME)/.local/share/icons/hicolor
+
+install:
+	cargo build --release --workspace --exclude banshee-app
+	mkdir -p "$(BIN_DIR)"
+	ln -sf "$(CURDIR)/target/release/banshee" "$(BIN_DIR)/banshee"
+	ln -sf "$(CURDIR)/target/release/banshee-mcp-shim" "$(BIN_DIR)/banshee-mcp-shim"
+	# A machine with no user systemd bus fails this step. The install must not
+	# abort here, since the symlinks above already point at a working build.
+	"$(BIN_DIR)/banshee" start || echo "could not register the systemd --user service; start it yourself with: $(BIN_DIR)/banshee serve"
+	@echo "installed to $(BIN_DIR); make sure it's on your PATH"
+
+.PHONY: install-window
+
+# Depends on `install`, so the daemon exists in target/release before the
+# window is installed. It needs GTK, WebKitGTK and Node, which `install` does
+# not, so a headless machine keeps its one-command install.
+install-window: install
+	cd banshee-app/ui && npm ci
+	cd banshee-app && cargo tauri build --no-bundle
+	mkdir -p "$(BIN_DIR)" "$(DESKTOP_DIR)" "$(ICON_DIR)/512x512/apps"
+	# Canonicalised at run time, so the window finds `banshee` in target/release.
+	ln -sf "$(CURDIR)/target/release/banshee-app" "$(BIN_DIR)/banshee-app"
+	cp assets/banshee-icon.png "$(ICON_DIR)/512x512/apps/banshee.png"
+	sed -e 's|@BIN_DIR@|$(BIN_DIR)|' packaging/banshee.desktop > "$(DESKTOP_DIR)/banshee.desktop"
+	update-desktop-database "$(DESKTOP_DIR)" 2>/dev/null || true
+	@echo "installed the window; open Banshee from your launcher"
+
+endif

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ knows about, and changes nothing itself.
 |                       | With the desktop window                                                                 | Terminal only                          |
 | --------------------- | --------------------------------------------------------------------------------------- | -------------------------------------- |
 | macOS (Apple Silicon) | [the cask](#macos-with-the-window), or [a direct download](#macos-without-homebrew)       | [the formula](#macos-terminal-only)    |
-| Linux (x86_64, arm64) | not yet                                                                                   | [the formula or the installer](#linux) |
+| Linux (x86_64, arm64) | [from source](docs/linux.md#building-the-desktop-window)                                 | [the formula or the installer](#linux) |
 | Windows               | not yet                                                                                   | not yet                                |
 
 Pick one. Needs ~1 GB of disk for the models. Intel Macs are not supported.
@@ -118,6 +118,9 @@ bar. See [docs/linux.md](docs/linux.md) for the typing tool and the service.
 ### From source
 
 Clone the repo and run `make install`; see [CONTRIBUTING.md](CONTRIBUTING.md).
+It works on macOS and Linux. On Linux it also registers and starts the
+`systemd --user` service, where systemd answers. Without it the install still
+finishes, and `banshee serve` starts the daemon.
 
 ## Set up from the terminal
 

--- a/banshee-app/src/commands.rs
+++ b/banshee-app/src/commands.rs
@@ -177,6 +177,59 @@ mod tests {
             true
         )));
     }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn starting_the_daemon_leaves_a_running_unit_alone() {
+        assert_eq!(
+            super::systemctl_args(banshee_common::utils::DAEMON_AGENT, false),
+            Some(vec![
+                "--user".to_string(),
+                "start".to_string(),
+                "banshee.service".to_string(),
+            ])
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn restarting_the_daemon_tears_the_unit_down_first() {
+        assert_eq!(
+            super::systemctl_args(banshee_common::utils::DAEMON_AGENT, true),
+            Some(vec![
+                "--user".to_string(),
+                "restart".to_string(),
+                "banshee.service".to_string(),
+            ])
+        );
+    }
+
+    // Nothing may start a tray unit before phase 2 writes one.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn the_tray_label_reaches_no_systemctl_call() {
+        assert_eq!(
+            super::systemctl_args(banshee_common::utils::TRAY_AGENT, false),
+            None
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn the_daemon_label_names_the_unit_that_bansheed_writes() {
+        assert_eq!(
+            super::systemd_unit(banshee_common::utils::DAEMON_AGENT),
+            Some("banshee.service")
+        );
+    }
+
+    // The tray unit lands with the Linux tray. Until it is written, a caller
+    // must not be handed a name it cannot start.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn the_tray_label_names_no_unit_yet() {
+        assert_eq!(super::systemd_unit(banshee_common::utils::TRAY_AGENT), None);
+    }
 }
 
 #[tauri::command]
@@ -369,6 +422,7 @@ pub fn run_cli(subcommand: &str) -> Result<(), CommandError> {
 ///
 /// It fails when the job was never bootstrapped, and the subcommand that
 /// installs it runs only then, because installing tears a running job down.
+#[cfg(target_os = "macos")]
 fn kickstart(label: &str, install: &str, replace: bool) -> Result<(), CommandError> {
     let target = utils::launchd_target(label);
     let mut args = vec!["kickstart"];
@@ -384,6 +438,39 @@ fn kickstart(label: &str, install: &str, replace: bool) -> Result<(), CommandErr
         return Ok(());
     }
     run_cli(install)
+}
+
+/// The systemd arm. `start` leaves a running unit alone and `restart` tears it
+/// down, which is what `replace` means on launchd. Any failure falls through to
+/// the CLI: the label may name a unit nobody wrote yet, such as a fresh
+/// install where `banshee start` has not run.
+#[cfg(not(target_os = "macos"))]
+fn kickstart(label: &str, install: &str, replace: bool) -> Result<(), CommandError> {
+    if let Some(args) = systemctl_args(label, replace) {
+        let started = std::process::Command::new("systemctl").args(&args).status();
+        if matches!(&started, Ok(status) if status.success()) {
+            return Ok(());
+        }
+    }
+    run_cli(install)
+}
+
+/// Split from the call, so a test can read the argv without starting a unit.
+#[cfg(not(target_os = "macos"))]
+fn systemctl_args(label: &str, replace: bool) -> Option<Vec<String>> {
+    let unit = systemd_unit(label)?;
+    let verb = if replace { "restart" } else { "start" };
+    Some(vec!["--user".to_string(), verb.to_string(), unit.to_string()])
+}
+
+/// The unit that runs the job a launchd label names. `None` where no unit file
+/// exists, so a caller cannot start one that was never written.
+#[cfg(not(target_os = "macos"))]
+fn systemd_unit(label: &str) -> Option<&'static str> {
+    match label {
+        utils::DAEMON_AGENT => Some(utils::DAEMON_UNIT),
+        _ => None,
+    }
 }
 
 /// Puts the menu bar icon up. Not a second copy of the binary, which the

--- a/banshee-app/src/main.rs
+++ b/banshee-app/src/main.rs
@@ -4,6 +4,7 @@ use tauri::{Emitter, Manager};
 
 // Opening a menu bar app is what puts its icon up. Off this thread, because
 // launchd can take seconds and the window must not wait for it.
+#[cfg(target_os = "macos")]
 fn start_the_icon() {
     std::thread::spawn(|| {
         if let Err(error) = commands::open_the_tray() {
@@ -11,6 +12,11 @@ fn start_the_icon() {
         }
     });
 }
+
+// No tray process runs here yet. `banshee watch --waybar` reports the state
+// until phase 2 lands one.
+#[cfg(not(target_os = "macos"))]
+fn start_the_icon() {}
 
 fn main() {
     tauri::Builder::default()

--- a/banshee-app/ui/src/bands/Ledger.svelte
+++ b/banshee-app/ui/src/bands/Ledger.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { formatCount } from '../lib/history';
+  import { findChord } from '../lib/keys';
   import SaveSwitch from '../controls/SaveSwitch.svelte';
 
   export let total: number;
@@ -21,7 +22,7 @@
   <SaveSwitch {saving} />
 
   {#if saving && total > 1}
-    <span class="hint caps mono">&#8984;F to find</span>
+    <span class="hint caps mono">{findChord()} to find</span>
   {/if}
 </div>
 

--- a/banshee-app/ui/src/lib/keys.test.ts
+++ b/banshee-app/ui/src/lib/keys.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { findChord } from './keys';
+
+const MAC = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15';
+const LINUX = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15';
+
+describe('findChord', () => {
+  it('draws the Command glyph on macOS', () => {
+    expect(findChord(MAC)).toBe('⌘F');
+  });
+
+  // A Linux keyboard has no Command key, so the glyph names a key nobody has.
+  it('names Control everywhere else', () => {
+    expect(findChord(LINUX)).toBe('Ctrl+F');
+  });
+});

--- a/banshee-app/ui/src/lib/keys.ts
+++ b/banshee-app/ui/src/lib/keys.ts
@@ -31,3 +31,11 @@ export function keysClaimed(): boolean {
 export function forgetKeys(): void {
   held = false;
 }
+
+/// The chord that opens Find, written the way the host platform names it.
+/// macOS draws the Command glyph; every other platform holds Control. The
+/// window runs inside the platform's own webview, and Tauri names no platform
+/// without a plugin, so the user agent is what is left to read.
+export function findChord(userAgent: string = navigator.userAgent): string {
+  return userAgent.includes('Mac OS X') ? '\u2318F' : 'Ctrl+F';
+}

--- a/banshee-common/src/utils.rs
+++ b/banshee-common/src/utils.rs
@@ -36,6 +36,10 @@ pub fn sibling_command(name: &str) -> Result<std::process::Command, BansheeError
 pub const DAEMON_AGENT: &str = "com.banshee.daemon";
 pub const TRAY_AGENT: &str = "com.banshee.tray";
 
+/// systemd's name for the daemon's user unit. `bansheed` writes the file and
+/// `banshee-app` starts it, so the spelling is shared.
+pub const DAEMON_UNIT: &str = "banshee.service";
+
 /// What launchctl calls one job of the logged-in user.
 pub fn launchd_target(label: &str) -> String {
     format!("gui/{}/{label}", uid())

--- a/bansheed/src/hotkey.rs
+++ b/bansheed/src/hotkey.rs
@@ -122,6 +122,12 @@ pub fn usage_hint(hotkey: Hotkey, hotkey_mode: HotkeyMode) -> String {
     if crate::dictation::is_wayland() {
         return format!("{WAYLAND_HOTKEY_HINT}.");
     }
+    bound_key_hint(hotkey, hotkey_mode)
+}
+
+// Split from `usage_hint`, which answers from the live session. A test cannot
+// choose the session it runs under, so it reads this half instead.
+fn bound_key_hint(hotkey: Hotkey, hotkey_mode: HotkeyMode) -> String {
     let press = match hotkey_mode {
         HotkeyMode::Toggle => format!("Tap {hotkey} and speak, then tap it again to stop."),
         HotkeyMode::Hold => format!("Hold {hotkey} and speak, then release to stop."),
@@ -498,11 +504,11 @@ mod hint_tests {
 
     #[test]
     fn the_hint_matches_the_mode_in_effect() {
-        let toggle = usage_hint(Hotkey::default(), HotkeyMode::Toggle);
+        let toggle = bound_key_hint(Hotkey::default(), HotkeyMode::Toggle);
         assert!(toggle.contains("again"), "toggle must say to press twice");
         assert!(!toggle.contains("release"), "toggle must not say release");
 
-        let hold = usage_hint(Hotkey::default(), HotkeyMode::Hold);
+        let hold = bound_key_hint(Hotkey::default(), HotkeyMode::Hold);
         assert!(hold.contains("release"), "hold must say to release");
         assert!(!hold.contains("again"), "hold must not say to press twice");
     }
@@ -512,7 +518,7 @@ mod hint_tests {
     fn the_hint_names_the_key_the_listener_matches() {
         let rebound = hotkey("F6").unwrap();
         for mode in [HotkeyMode::Toggle, HotkeyMode::Hold] {
-            let hint = usage_hint(rebound, mode);
+            let hint = bound_key_hint(rebound, mode);
             assert!(hint.contains("F6"), "the bound key must be named: {hint}");
             assert!(
                 !hint.contains("RightOption"),

--- a/bansheed/src/service.rs
+++ b/bansheed/src/service.rs
@@ -184,7 +184,7 @@ mod systemd {
 
     use banshee_common::error::BansheeError;
 
-    const UNIT: &str = "banshee.service";
+    const UNIT: &str = banshee_common::utils::DAEMON_UNIT;
 
     pub fn service_file_path() -> Option<PathBuf> {
         Some(dirs::config_dir()?.join("systemd/user").join(UNIT))

--- a/bansheed/src/settings/tests.rs
+++ b/bansheed/src/settings/tests.rs
@@ -472,7 +472,7 @@ fn a_setting_whose_file_is_still_missing_keeps_waiting() {
 #[test]
 fn a_restart_only_key_is_left_alone() {
     let running: Config =
-        toml::from_str("[audio]\nhotkey = \"RightCommand\"\n").expect("a legal binding");
+        toml::from_str("[audio]\nhotkey = \"LeftControl\"\n").expect("a legal binding");
     let state = crate::test_support::daemon_state_running(running, std::sync::mpsc::channel().0);
     let next: Config =
         toml::from_str("[audio]\nhotkey = \"LeftCommand\"\n").expect("a legal binding");
@@ -502,10 +502,10 @@ fn a_key_that_needs_a_restart_becomes_pending_and_a_live_one_does_not() {
 #[test]
 fn a_restart_only_key_set_to_the_value_already_running_needs_no_restart() {
     let running: Config =
-        toml::from_str("[audio]\nhotkey = \"RightCommand\"\n").expect("a legal binding");
+        toml::from_str("[audio]\nhotkey = \"LeftControl\"\n").expect("a legal binding");
     let state = crate::test_support::daemon_state_running(running, std::sync::mpsc::channel().0);
     let next: Config =
-        toml::from_str("[audio]\nhotkey = \"RightCommand\"\n").expect("a legal binding");
+        toml::from_str("[audio]\nhotkey = \"LeftControl\"\n").expect("a legal binding");
 
     let keys = vec!["audio.hotkey".to_string()];
     let outcome = super::apply_each(&state, &next, keys.iter());
@@ -523,7 +523,7 @@ fn a_restart_only_key_set_to_the_value_already_running_needs_no_restart() {
 #[test]
 fn a_restart_only_key_set_to_a_different_value_still_waits() {
     let running: Config =
-        toml::from_str("[audio]\nhotkey = \"RightCommand\"\n").expect("a legal binding");
+        toml::from_str("[audio]\nhotkey = \"LeftControl\"\n").expect("a legal binding");
     let state = crate::test_support::daemon_state_running(running, std::sync::mpsc::channel().0);
     let next: Config =
         toml::from_str("[audio]\nhotkey = \"LeftCommand\"\n").expect("a legal binding");

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,24 +1,84 @@
 # Linux
 
-The daemon, the CLI and the agent voice work the same as on macOS. Two things
-differ, both below. The desktop window is macOS only today.
+The daemon, the CLI and the agent voice work the same as on macOS. The
+sections below cover what is different: the desktop window, the Wayland
+hotkey, and the Waybar module.
+
+## Building the desktop window
+
+The window is a Tauri app. It needs WebKitGTK, GTK 3 and Node 22. The daemon
+and the CLI need none of these.
+
+```bash
+# Arch
+sudo pacman -S --needed webkit2gtk-4.1
+# Debian and Ubuntu
+sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev
+# Fedora (untested)
+sudo dnf install webkit2gtk4.1-devel gtk3-devel librsvg2-devel
+```
+
+Then:
+
+```bash
+cargo install tauri-cli --version "^2" --locked
+make install-window
+```
+
+`make install` builds and installs the daemon and the CLI. A machine with no
+GTK still runs it.
+
+`make install-window` depends on `install`, so it installs the daemon, the
+CLI and the window together. It needs GTK, WebKitGTK and Node 22. It puts
+`banshee-app` in `~/.local/bin`, a desktop entry in
+`~/.local/share/applications`, and icons in
+`~/.local/share/icons/hicolor`. The launcher then opens the window with WM
+class `banshee-app`.
+
+The install points `banshee-app` at `target/release`, so a `cargo clean` or a
+moved clone breaks the window's daemon control. Run `make install-window`
+again to put it back.
+
+There is no tray icon here yet. `banshee-tray` still exits on Linux.
+`banshee watch --waybar` reports the state instead.
 
 ## The hotkey on Wayland
 
 The global hotkey needs X11, so on a Wayland session (Hyprland, Sway, GNOME)
-bind the record commands in your compositor instead. For push-to-talk on `F5`,
-put these in `~/.config/hypr/hyprland.conf` (or `bindings.conf` on Omarchy),
-then run `hyprctl reload`:
+bind the record commands in your compositor instead. For push-to-talk on
+`F5`:
+
+**Hyprland**, in `~/.config/hypr/hyprland.conf` or `bindings.conf`, then run
+`hyprctl reload`:
 
 ```conf
 bind  = , F5, exec, banshee record start --dictate
-bindr = , F5, exec, banshee record stop           # bindr fires on release
+bindr = , F5, exec, banshee record stop
 bind  = SHIFT, F5, exec, banshee record start
 bindr = SHIFT, F5, exec, banshee record stop
 ```
 
-Both release binds are there on purpose: Hyprland matches modifiers exactly,
-and `Shift` may be released before `F5`.
+**Omarchy** configures Hyprland through Lua, not `hyprland.conf`. There is
+no `bindings.conf`. Put these in `~/.config/hypr/bindings.lua` instead, then
+run `hyprctl reload`:
+
+```lua
+o.bind("F5", "Banshee: start dictation", "banshee record start --dictate")
+o.bind("F5", nil, "banshee record stop", { release = true })
+o.bind("SHIFT + F5", "Banshee: start recording", "banshee record start")
+o.bind("SHIFT + F5", nil, "banshee record stop", { release = true })
+```
+
+Both release binds are there on purpose, in either config style: Hyprland
+matches modifiers exactly, and `Shift` may be released before `F5`.
+
+Bind an ordinary key, not a modifier. Hyprland cannot dispatch a bare
+modifier's press action immediately, because the press might still become
+the start of a different chord. It only knows once the key is released, so
+it fires the press and release binds together at that point, regardless of
+how long the key was actually held. A `Right Alt`-only bind plays both
+earcons back to back and never captures audio. `F5` is not a modifier, so it
+has no such ambiguity and dispatches its press bind immediately.
 
 Typing into the focused app needs **`wtype`** (wlroots compositors) or
 **`ydotool`** (anywhere, with its own daemon and uinput access). Without one,

--- a/packaging/banshee.desktop
+++ b/packaging/banshee.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Banshee
+Comment=Give your AI coding agent a voice
+Exec="@BIN_DIR@/banshee-app"
+Icon=banshee
+Terminal=false
+Categories=Utility;
+StartupWMClass=banshee-app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Linux installation support for the desktop window, including application launcher and icons.
  - Linux installations can register and start Banshee as a user service.
  - Added documented Linux setup instructions for desktop dependencies and Wayland hotkeys.

- **Bug Fixes**
  - The Find shortcut hint now displays `⌘F` on macOS and `Ctrl+F` on other platforms.

- **Documentation**
  - Updated installation and build guidance for macOS and Linux, including desktop window setup and service management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->