### PR TITLE
feat: the tray runs on linux and one search finds the typer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev libx11-dev libxtst-dev libxi-dev libxdo-dev
+      # libgtk-3-dev is for the tray, which links gtk on every platform but macOS.
+      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev libx11-dev libxtst-dev libxi-dev libxdo-dev libgtk-3-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # The same pinned model the macos job checks; see the reason there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The menu bar icon now runs on Linux.** `banshee tray` puts the mark in any
+  bar that hosts StatusNotifierItem, and the desktop window starts it for you.
+  The menu names the state and the microphone, copies your last dictation, and
+  opens the window. Right click opens it; left click waits on a fix upstream.
+
 - **The desktop window now builds and installs on Linux.** Run `make
   install-window` from a source clone to build it; it needs GTK, WebKitGTK
   and Node 22. The install adds a desktop entry and icons, so your launcher
-  finds Banshee. There is still no tray icon on Linux.
+  finds Banshee.
+
+- **The window now shows a blocker when no Wayland typer is installed.** Off
+  macOS, dictation types by shelling out to `wtype` or `ydotool`. `banshee
+  status` already named a missing one, but the window's blockers band stayed
+  empty. It now lists a blocker for the missing tool, and names `wtype` and
+  `ydotool` as the fix.
 
 ### Fixed
+
+- **Dictation runs the typing tool it told you about.** The daemon looked up
+  `wtype` and `ydotool` in its own `PATH`, while `banshee status` looked in the
+  login shell's. A supervised daemon holds the smaller one, so the checklist
+  could name a tool the daemon could not run. One search now answers both, and
+  every installed tool gets a turn before dictation reports a failure.
 
 - **The window stops naming a hotkey nobody listens for.** On Wayland no
   protocol grants a global hotkey, so Banshee binds none and the compositor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ cargo build --release --workspace --exclude banshee-app
 ```
 
 This produces `target/release/banshee` and `target/release/banshee-mcp-shim`.
-`banshee-tray` also builds, but it exits immediately and points you at
-`banshee watch --waybar`. See [docs/linux.md](docs/linux.md). An `nvidia`
+`banshee-tray` also builds, and `banshee tray` runs it. See
+[docs/linux.md](docs/linux.md). An `nvidia`
 feature adds CUDA acceleration: add `--features nvidia`.
 
 To also link the binaries onto your `PATH` and register the `systemd --user`
@@ -126,7 +126,7 @@ service.
 `make install-window` depends on `install`, so it builds and installs the
 daemon, the CLI and the desktop window together. See
 [docs/linux.md](docs/linux.md) for what it needs. There is no signing step.
-There is no tray icon yet. Run `banshee watch --waybar` instead.
+`banshee tray` puts the mark in the bar.
 
 ## Submitting changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "cpal",
  "dirs",
  "enigo",
+ "gtk",
  "hound",
  "json5",
  "misaki-rs",

--- a/banshee-app/src/commands.rs
+++ b/banshee-app/src/commands.rs
@@ -204,31 +204,17 @@ mod tests {
         );
     }
 
-    // Nothing may start a tray unit before phase 2 writes one.
     #[cfg(not(target_os = "macos"))]
     #[test]
-    fn the_tray_label_reaches_no_systemctl_call() {
+    fn starting_the_tray_names_its_unit() {
         assert_eq!(
             super::systemctl_args(banshee_common::utils::TRAY_AGENT, false),
-            None
+            Some(vec![
+                "--user".to_string(),
+                "start".to_string(),
+                "banshee-tray.service".to_string(),
+            ])
         );
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn the_daemon_label_names_the_unit_that_bansheed_writes() {
-        assert_eq!(
-            super::systemd_unit(banshee_common::utils::DAEMON_AGENT),
-            Some("banshee.service")
-        );
-    }
-
-    // The tray unit lands with the Linux tray. Until it is written, a caller
-    // must not be handed a name it cannot start.
-    #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn the_tray_label_names_no_unit_yet() {
-        assert_eq!(super::systemd_unit(banshee_common::utils::TRAY_AGENT), None);
     }
 }
 
@@ -458,19 +444,9 @@ fn kickstart(label: &str, install: &str, replace: bool) -> Result<(), CommandErr
 /// Split from the call, so a test can read the argv without starting a unit.
 #[cfg(not(target_os = "macos"))]
 fn systemctl_args(label: &str, replace: bool) -> Option<Vec<String>> {
-    let unit = systemd_unit(label)?;
+    let unit = utils::systemd_unit(label)?;
     let verb = if replace { "restart" } else { "start" };
     Some(vec!["--user".to_string(), verb.to_string(), unit.to_string()])
-}
-
-/// The unit that runs the job a launchd label names. `None` where no unit file
-/// exists, so a caller cannot start one that was never written.
-#[cfg(not(target_os = "macos"))]
-fn systemd_unit(label: &str) -> Option<&'static str> {
-    match label {
-        utils::DAEMON_AGENT => Some(utils::DAEMON_UNIT),
-        _ => None,
-    }
 }
 
 /// Puts the menu bar icon up. Not a second copy of the binary, which the

--- a/banshee-app/src/main.rs
+++ b/banshee-app/src/main.rs
@@ -4,7 +4,6 @@ use tauri::{Emitter, Manager};
 
 // Opening a menu bar app is what puts its icon up. Off this thread, because
 // launchd can take seconds and the window must not wait for it.
-#[cfg(target_os = "macos")]
 fn start_the_icon() {
     std::thread::spawn(|| {
         if let Err(error) = commands::open_the_tray() {
@@ -12,11 +11,6 @@ fn start_the_icon() {
         }
     });
 }
-
-// No tray process runs here yet. `banshee watch --waybar` reports the state
-// until phase 2 lands one.
-#[cfg(not(target_os = "macos"))]
-fn start_the_icon() {}
 
 fn main() {
     tauri::Builder::default()

--- a/banshee-common/src/utils.rs
+++ b/banshee-common/src/utils.rs
@@ -40,6 +40,18 @@ pub const TRAY_AGENT: &str = "com.banshee.tray";
 /// `banshee-app` starts it, so the spelling is shared.
 pub const DAEMON_UNIT: &str = "banshee.service";
 
+/// systemd's name for the tray's user unit.
+pub const TRAY_UNIT: &str = "banshee-tray.service";
+
+/// The unit that runs the job a launchd label names.
+pub fn systemd_unit(label: &str) -> Option<&'static str> {
+    match label {
+        DAEMON_AGENT => Some(DAEMON_UNIT),
+        TRAY_AGENT => Some(TRAY_UNIT),
+        _ => None,
+    }
+}
+
 /// What launchctl calls one job of the logged-in user.
 pub fn launchd_target(label: &str) -> String {
     format!("gui/{}/{label}", uid())
@@ -147,5 +159,20 @@ async fn call(
             code: error.code,
             message: error.message,
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_daemon_label_names_its_own_unit() {
+        assert_eq!(systemd_unit(DAEMON_AGENT), Some(DAEMON_UNIT));
+    }
+
+    #[test]
+    fn the_tray_label_names_its_own_unit() {
+        assert_eq!(systemd_unit(TRAY_AGENT), Some("banshee-tray.service"));
     }
 }

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -44,20 +44,40 @@ tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "net", "i
 toml = "1.1.2"
 toml_edit = { version = "0.25", features = ["serde"] }
 whisper-rs = "0.16.0"
+# The mark is a png on every platform. winit is macOS only, below.
+png = "0.18.1"
+
+[target.'cfg(target_os = "macos")'.dependencies.tray-icon]
+version = "0.24.2"
+
+# `libxdo` is a default feature, and muda uses it only to work the predefined
+# Copy, Cut, Paste and SelectAll menu items. This menu has none of them, so the
+# feature would buy a build dependency on xdotool and nothing else.
+[target.'cfg(not(target_os = "macos"))'.dependencies.tray-icon]
+version = "0.24.2"
+default-features = false
+features = ["gtk"]
+
+# arboard talks X11 by default. A Wayland session has no X11 clipboard of its
+# own, so without this feature the text is set where nothing reads it.
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies.arboard]
+version = "3.6.1"
+features = ["wayland-data-control"]
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 enigo = "0.6.1"
+# The tray builds gtk widgets, so a gtk loop must own the thread. macOS needs no
+# entry here: AppKit's own loop already serves the icon.
+gtk = "0.18.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# The menu bar indicator's loop. winit runs it because tray-icon tests against
+# it and it commits to no toolkit. The gtk loop serves every other platform.
+winit = "0.30.13"
 # The options dictionary AXIsProcessTrustedWithOptions takes; see permissions.rs.
 core-foundation = "0.10"
 # Posts the paste keystroke with its modifier as a flag; see dictation.rs.
 core-graphics = "0.25"
-# The menu bar indicator. winit runs the loop because tray-icon tests against
-# it and it commits to no toolkit.
-png = "0.18.1"
-tray-icon = "0.24.2"
-winit = "0.30.13"
 # Metal + CoreML are always on for macOS (including prebuilt release binaries);
 # whisper.cpp falls back to CPU at runtime if the GPU path is unavailable.
 whisper-rs = { version = "0.16.0", features = ["metal", "coreml"] }

--- a/bansheed/src/bin/banshee-tray.rs
+++ b/bansheed/src/bin/banshee-tray.rs
@@ -1,35 +1,34 @@
-//! The macOS menu bar indicator.
+//! The menu bar indicator.
 //!
-//! A separate process from the daemon. AppKit must own the main thread, and the
-//! daemon's belongs to tokio. Reading the socket is all this does, so it needs
-//! no TCC grants of its own.
+//! A separate process from the daemon. AppKit owns the main thread on macOS and
+//! gtk owns it elsewhere, while the daemon's thread belongs to tokio. Reading
+//! the socket is all this does, so it needs no TCC grants of its own.
 
-#[cfg(not(target_os = "macos"))]
 fn main() {
-    eprintln!("banshee-tray runs on macOS only. Elsewhere use: banshee watch --waybar");
-    std::process::exit(1);
-}
-
-#[cfg(target_os = "macos")]
-fn main() {
-    if let Err(error) = mac::run() {
+    if let Err(error) = tray::run() {
         eprintln!("banshee-tray: {error}");
         std::process::exit(1);
     }
 }
 
-#[cfg(target_os = "macos")]
-mod mac {
+mod tray {
     use std::time::Duration;
 
     use banshee_common::{Activity, BANSHEE_HISTORY, BANSHEE_STATE_CHANGED, EVENT_STATE, utils};
     use serde_json::Value;
     use tray_icon::menu::{IsMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem};
     use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
+    #[cfg(not(target_os = "macos"))]
+    use gtk::glib;
+    #[cfg(target_os = "macos")]
     use winit::application::ApplicationHandler;
+    #[cfg(target_os = "macos")]
     use winit::event::WindowEvent;
+    #[cfg(target_os = "macos")]
     use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
+    #[cfg(target_os = "macos")]
     use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
+    #[cfg(target_os = "macos")]
     use winit::window::WindowId;
 
     const QUIT_ID: &str = "quit";
@@ -46,6 +45,12 @@ mod mac {
     // stale `Not running` after the daemon returns against how often an idle
     // machine wakes to a failing connect.
     const RETRY: Duration = Duration::from_secs(2);
+
+    // The gtk loop keeps no queue for these messages, so it reads the channel on
+    // a timer. Nothing measured this number. It trades how soon the icon answers
+    // a click against how often an idle loop wakes to an empty channel.
+    #[cfg(not(target_os = "macos"))]
+    const POLL: Duration = Duration::from_millis(100);
 
     /// What the menu bar shows. `Activity` ranks the booleans the daemon
     /// pushes; the last state is the daemon failing to answer at all.
@@ -97,7 +102,25 @@ mod mac {
         let mut pixels = vec![0; reader.output_buffer_size().ok_or("icon too large")?];
         let info = reader.next_frame(&mut pixels)?;
         pixels.truncate(info.buffer_size());
+        tint(&mut pixels);
         Ok((pixels, info.width, info.height))
+    }
+
+    // macOS paints a template image from the alpha and picks the colour itself.
+    // Every other platform draws the RGB it is given, and the assets are black,
+    // so the mark has to carry its own colour there. `#e2673d` is the accent the
+    // window uses on a dark ground.
+    #[cfg(target_os = "macos")]
+    fn tint(_pixels: &mut [u8]) {}
+
+    #[cfg(not(target_os = "macos"))]
+    fn tint(pixels: &mut [u8]) {
+        for pixel in pixels.as_chunks_mut::<4>().0 {
+            // The alpha is the drawing. Only the colour under it changes.
+            pixel[0] = 0xe2;
+            pixel[1] = 0x67;
+            pixel[2] = 0x3d;
+        }
     }
 
     fn icon(indicator: Indicator) -> Result<Icon, Box<dyn std::error::Error>> {
@@ -115,6 +138,34 @@ mod mac {
         Open,
         CopyLast,
         Copied(String),
+    }
+
+    /// Hands a `Message` to whoever owns the tray. winit carries one as a user
+    /// event, and the gtk loop reads one from a channel.
+    trait Postbox: Clone + Send + 'static {
+        /// False once the far end is gone, which means the process is on its way
+        /// out and this thread with it.
+        fn post(&self, message: Message) -> bool;
+    }
+
+    #[cfg(target_os = "macos")]
+    impl Postbox for EventLoopProxy<Message> {
+        fn post(&self, message: Message) -> bool {
+            self.send_event(message).is_ok()
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    impl Postbox for std::sync::mpsc::Sender<Message> {
+        fn post(&self, message: Message) -> bool {
+            self.send(message).is_ok()
+        }
+    }
+
+    /// What `App::handle` asks the loop to do next.
+    enum Flow {
+        Stay,
+        Exit,
     }
 
     #[derive(Debug, Default, PartialEq, Eq)]
@@ -201,35 +252,26 @@ mod mac {
         _menu: Menu,
     }
 
-    struct App {
+    struct App<P: Postbox> {
         ui: Option<Ui>,
         indicator: Indicator,
         device: Device,
         history_enabled: bool,
-        proxy: EventLoopProxy<Message>,
+        postbox: P,
     }
 
-    impl App {
-        fn show(&self) {
-            let Some(ui) = &self.ui else { return };
-            ui.state_item.set_text(self.indicator.label());
-            ui.device_item
-                .set_text(device_line(self.indicator, &self.device));
-            ui.copy_item
-                .set_enabled(copy_last_enabled(self.indicator, self.history_enabled));
-            if let Err(error) = draw(&ui.tray, self.indicator) {
-                eprintln!("banshee-tray: could not draw the icon: {error}");
+    impl<P: Postbox> App<P> {
+        fn new(postbox: P) -> Self {
+            Self {
+                ui: None,
+                indicator: Indicator::NotRunning,
+                device: Device::default(),
+                history_enabled: false,
+                postbox,
             }
         }
-    }
 
-    fn draw(tray: &TrayIcon, indicator: Indicator) -> Result<(), Box<dyn std::error::Error>> {
-        tray.set_icon_with_as_template(Some(icon(indicator)?), true)?;
-        Ok(())
-    }
-
-    impl ApplicationHandler<Message> for App {
-        fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
+        fn start(&mut self) {
             if self.ui.is_some() {
                 return;
             }
@@ -242,7 +284,7 @@ mod mac {
             }
         }
 
-        fn user_event(&mut self, event_loop: &ActiveEventLoop, message: Message) {
+        fn handle(&mut self, message: Message) -> Flow {
             // Redrawing costs a decode, a re-encode and a menu bar repaint, and
             // the reconnect loop repeats itself once a cycle while the daemon is
             // down, so an unchanged value must not reach show()
@@ -253,7 +295,7 @@ mod mac {
                 Message::Quit => {
                     close_the_window().unwrap_or_else(|e| eprintln!("banshee-tray: {e}"));
                     stop_the_daemon().unwrap_or_else(|e| eprintln!("banshee-tray: {e}"));
-                    return event_loop.exit();
+                    return Flow::Exit;
                 }
                 Message::State(indicator) => {
                     let moved = self.indicator != indicator;
@@ -271,17 +313,59 @@ mod mac {
                     moved
                 }
                 Message::Open => {
-                    return open_the_window()
-                        .unwrap_or_else(|error| eprintln!("banshee-tray: {error}"));
+                    open_the_window().unwrap_or_else(|error| eprintln!("banshee-tray: {error}"));
+                    return Flow::Stay;
                 }
-                Message::CopyLast => return spawn_copy_last(self.proxy.clone()),
+                Message::CopyLast => {
+                    spawn_copy_last(self.postbox.clone());
+                    return Flow::Stay;
+                }
                 Message::Copied(text) => {
-                    return copy_to_clipboard(&text)
+                    copy_to_clipboard(&text)
                         .unwrap_or_else(|error| eprintln!("banshee-tray: {error}"));
+                    return Flow::Stay;
                 }
             };
             if changed {
                 self.show();
+            }
+            Flow::Stay
+        }
+
+        fn show(&self) {
+            let Some(ui) = &self.ui else { return };
+            ui.state_item.set_text(self.indicator.label());
+            ui.device_item
+                .set_text(device_line(self.indicator, &self.device));
+            ui.copy_item
+                .set_enabled(copy_last_enabled(self.indicator, self.history_enabled));
+            if let Err(error) = draw(&ui.tray, self.indicator) {
+                eprintln!("banshee-tray: could not draw the icon: {error}");
+            }
+        }
+    }
+
+    fn draw(tray: &TrayIcon, indicator: Indicator) -> Result<(), Box<dyn std::error::Error>> {
+        // macOS tints a template image itself, so it takes the flag. Off macOS
+        // `set_icon_with_as_template` discards its arguments and answers Ok, so
+        // the icon would never change there.
+        #[cfg(target_os = "macos")]
+        tray.set_icon_with_as_template(Some(icon(indicator)?), true)?;
+        #[cfg(not(target_os = "macos"))]
+        tray.set_icon(Some(icon(indicator)?))?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    impl<P: Postbox> ApplicationHandler<Message> for App<P> {
+        fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
+            self.start();
+        }
+
+        fn user_event(&mut self, event_loop: &ActiveEventLoop, message: Message) {
+            match self.handle(message) {
+                Flow::Stay => {}
+                Flow::Exit => event_loop.exit(),
             }
         }
 
@@ -319,6 +403,9 @@ mod mac {
         menu.append_items(&refs)?;
 
         let tray = TrayIconBuilder::new()
+            // A bar pins an item by the id it reports. The crate's default id
+            // carries the process id, so a pin would not survive a restart.
+            .with_id("banshee")
             .with_menu(Box::new(menu.clone()))
             .with_icon(icon(Indicator::NotRunning)?)
             .with_icon_as_template(true)
@@ -336,10 +423,8 @@ mod mac {
 
     /// Any failure to read the socket is the daemon being unreachable: a state to show, not an
     /// error to report.
-    async fn watch(proxy: EventLoopProxy<Message>) {
-        // send_event fails only once the event loop is gone, which means the
-        // process is on its way out and this thread with it
-        let send = |message| proxy.send_event(message).is_ok();
+    async fn watch(postbox: impl Postbox) {
+        let send = |message| postbox.post(message);
         loop {
             if let Ok((status, mut changes)) = utils::Subscription::open(&[EVENT_STATE]).await {
                 if !send(Message::Device(Device::of(&status)))
@@ -365,7 +450,7 @@ mod mac {
         }
     }
 
-    fn spawn_copy_last(proxy: EventLoopProxy<Message>) {
+    fn spawn_copy_last(postbox: impl Postbox) {
         std::thread::spawn(move || {
             let runtime = match tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -386,7 +471,7 @@ mod mac {
             };
             match reply.as_ref().ok().and_then(last_history_entry) {
                 Some(text) => {
-                    let _ = proxy.send_event(Message::Copied(text.to_string()));
+                    postbox.post(Message::Copied(text.to_string()));
                 }
                 None => eprintln!("banshee-tray: no dictation to copy"),
             }
@@ -402,8 +487,38 @@ mod mac {
             .as_str()
     }
 
+    #[cfg(target_os = "macos")]
     fn copy_to_clipboard(text: &str) -> Result<(), Box<dyn std::error::Error>> {
         arboard::Clipboard::new()?.set_text(text)?;
+        Ok(())
+    }
+
+    // X11 and Wayland host the clipboard inside the process that last set it,
+    // so the text goes when the handle drops. macOS hands it to the system and
+    // needs none of this. The thread below owns the text until something else
+    // takes the clipboard, or until the hold runs out.
+    #[cfg(not(target_os = "macos"))]
+    fn copy_to_clipboard(text: &str) -> Result<(), Box<dyn std::error::Error>> {
+        use arboard::SetExtLinux;
+        use std::time::Instant;
+
+        // A copy a person asked for survives a detour to another window. The
+        // number is a judgement, not a measurement.
+        const HOLD: Duration = Duration::from_secs(600);
+
+        let text = text.to_string();
+        // The caller cannot see a failure past this thread, so it reports here.
+        std::thread::spawn(move || {
+            let mut clipboard = match arboard::Clipboard::new() {
+                Ok(clipboard) => clipboard,
+                Err(error) => return eprintln!("banshee-tray: no clipboard: {error}"),
+            };
+            // A dictation paste is excluded from clipboard history. This copy
+            // is deliberate, so it belongs there.
+            if let Err(error) = clipboard.set().wait_until(Instant::now() + HOLD).text(text) {
+                eprintln!("banshee-tray: the copy did not reach the clipboard: {error}");
+            }
+        });
         Ok(())
     }
 
@@ -459,49 +574,89 @@ mod mac {
         Ok(file)
     }
 
-    pub fn run() -> Result<(), Box<dyn std::error::Error>> {
-        // Held for the whole run: dropping it would free the lock
-        let _lock = claim_the_menu_bar()?;
+    fn menu_message(id: &str) -> Option<Message> {
+        match id {
+            QUIT_ID => Some(Message::Quit),
+            COPY_LAST_ID => Some(Message::CopyLast),
+            OPEN_ID => Some(Message::Open),
+            _ => None,
+        }
+    }
 
-        let event_loop = EventLoop::<Message>::with_user_event()
-            // No Dock icon and no menu bar of its own: this is furniture
-            .with_activation_policy(ActivationPolicy::Accessory)
-            .build()?;
-        event_loop.set_control_flow(ControlFlow::Wait);
-
-        let menu_proxy = event_loop.create_proxy();
-        MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
-            let message = match event.id.0.as_str() {
-                QUIT_ID => Some(Message::Quit),
-                COPY_LAST_ID => Some(Message::CopyLast),
-                OPEN_ID => Some(Message::Open),
-                _ => None,
-            };
-            if let Some(message) = message {
-                let _ = menu_proxy.send_event(message);
-            }
-        }));
-
-        // The subscription needs a runtime, and this thread is AppKit's
-        let watch_proxy = event_loop.create_proxy();
+    // The subscription needs a runtime, and the loop owns this thread
+    fn spawn_watch(postbox: impl Postbox) {
         std::thread::spawn(move || {
             match tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
             {
-                Ok(runtime) => runtime.block_on(watch(watch_proxy)),
+                Ok(runtime) => runtime.block_on(watch(postbox)),
                 Err(error) => eprintln!("banshee-tray: {error}"),
             }
         });
+    }
 
-        let mut app = App {
-            ui: None,
-            indicator: Indicator::NotRunning,
-            device: Device::default(),
-            history_enabled: false,
-            proxy: event_loop.create_proxy(),
-        };
+    #[cfg(target_os = "macos")]
+    pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+        // Held for the whole run: dropping it would free the lock
+        let _lock = claim_the_menu_bar()?;
+
+        let mut builder = EventLoop::<Message>::with_user_event();
+        // No Dock icon and no menu bar of its own: this is furniture
+        let builder = builder.with_activation_policy(ActivationPolicy::Accessory);
+        let event_loop = builder.build()?;
+        event_loop.set_control_flow(ControlFlow::Wait);
+
+        let menu_proxy = event_loop.create_proxy();
+        MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
+            if let Some(message) = menu_message(event.id.0.as_str()) {
+                menu_proxy.post(message);
+            }
+        }));
+
+        spawn_watch(event_loop.create_proxy());
+
+        let mut app = App::new(event_loop.create_proxy());
         event_loop.run_app(&mut app)?;
+        Ok(())
+    }
+
+    // tray-icon builds its menu out of gtk widgets, so a gtk loop must own the
+    // thread that builds the icon. winit's loop is not one.
+    #[cfg(not(target_os = "macos"))]
+    pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+        // Held for the whole run: dropping it would free the lock
+        let _lock = claim_the_menu_bar()?;
+
+        gtk::init()?;
+
+        let (sender, receiver) = std::sync::mpsc::channel::<Message>();
+
+        let menu_sender = sender.clone();
+        MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
+            if let Some(message) = menu_message(event.id.0.as_str()) {
+                menu_sender.post(message);
+            }
+        }));
+
+        spawn_watch(sender.clone());
+
+        let mut app = App::new(sender);
+        app.start();
+
+        glib::timeout_add_local(POLL, move || {
+            while let Ok(message) = receiver.try_recv() {
+                match app.handle(message) {
+                    Flow::Stay => {}
+                    Flow::Exit => {
+                        gtk::main_quit();
+                        return glib::ControlFlow::Break;
+                    }
+                }
+            }
+            glib::ControlFlow::Continue
+        });
+        gtk::main();
         Ok(())
     }
 
@@ -523,6 +678,44 @@ mod mac {
 
         fn mask(indicator: Indicator) -> (Vec<u8>, u32, u32) {
             glyph(indicator).expect("a shipped asset must decode")
+        }
+
+        // The assets are black with the drawing in the alpha, which macOS tints
+        // itself. Any other platform draws what it is given, so a black glyph on a
+        // dark bar is invisible.
+        #[cfg(not(target_os = "macos"))]
+        #[test]
+        fn the_linux_glyph_is_not_black() {
+            let (pixels, _, _) = glyph(Indicator::Idle).expect("the idle asset decodes");
+            let lit = pixels
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .filter(|p| p[3] > 40)
+                .any(|p| p[0] > 32 || p[1] > 32 || p[2] > 32);
+            assert!(lit, "every visible pixel is still black, so the bar shows nothing");
+        }
+
+        // The shape lives in the alpha channel, so a tint that touches it redraws
+        // the mark.
+        #[cfg(not(target_os = "macos"))]
+        #[test]
+        fn the_tint_leaves_the_shape_alone() {
+            let (tinted, w, h) = glyph(Indicator::Recording).expect("the asset decodes");
+            let raw = png::Decoder::new(std::io::Cursor::new(
+                &include_bytes!("../../assets/tray/mark-recording.png")[..],
+            ))
+            .read_info()
+            .and_then(|mut r| {
+                let mut buf = vec![0; r.output_buffer_size().unwrap()];
+                let info = r.next_frame(&mut buf)?;
+                buf.truncate(info.buffer_size());
+                Ok(buf)
+            })
+            .expect("the asset decodes twice");
+            assert_eq!(tinted.len(), raw.len(), "{w}x{h} must not change size");
+            let alpha_of = |v: &[u8]| v.as_chunks::<4>().0.iter().map(|p| p[3]).collect::<Vec<_>>();
+            assert_eq!(alpha_of(&tinted), alpha_of(&raw), "the alpha carries the mark");
         }
 
         fn device(open: Option<&str>, missing: Option<&str>) -> Device {
@@ -670,6 +863,9 @@ mod mac {
             assert_eq!(pixels.len(), (width * height * 4) as usize);
         }
 
+        // Off macOS, tint() paints real colour into these same pixels on purpose,
+        // so this invariant is macOS's alone.
+        #[cfg(target_os = "macos")]
         #[test]
         fn every_glyph_draws_in_alpha_only() {
             // A template image is painted by macOS, so a coloured asset renders

--- a/bansheed/src/dictation.rs
+++ b/bansheed/src/dictation.rs
@@ -95,37 +95,75 @@ fn send_paste() -> Result<(), Box<dyn Error>> {
 #[cfg(all(unix, not(target_os = "macos")))]
 pub const WAYLAND_TYPERS: [(&str, &[&str]); 2] = [("wtype", &["--"]), ("ydotool", &["type", "--"])];
 
+// One search, so the spawn, the checklist and the blocker cannot disagree
+// about what the daemon can run.
 #[cfg(all(unix, not(target_os = "macos")))]
-fn type_text_wayland(text: &str) -> Result<(), Box<dyn Error>> {
+pub(crate) fn resolve_wayland_typers(
+    path: &std::ffi::OsStr,
+) -> Vec<(std::path::PathBuf, &'static [&'static str])> {
+    WAYLAND_TYPERS
+        .into_iter()
+        .filter_map(|(binary, args)| crate::status::resolve(binary, path).map(|bin| (bin, args)))
+        .collect()
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn resolve_wayland_typer(
+    path: &std::ffi::OsStr,
+) -> Option<(std::path::PathBuf, &'static [&'static str])> {
+    resolve_wayland_typers(path).into_iter().next()
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn no_typer_error() -> Box<dyn Error> {
+    // Never Ok here: the caller plays the ready cue on Ok.
+    "could not type into the focused window on wayland (no typer on PATH); \
+     install 'wtype' (or 'ydotool'). the transcription is still in `banshee history`"
+        .into()
+}
+
+// GNOME/Mutter denies wtype the virtual-keyboard protocol it needs, so the
+// first typer resolved is not always the one that can run.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn type_with(
+    resolved: &[(std::path::PathBuf, &'static [&'static str])],
+    text: &str,
+) -> Result<(), Box<dyn Error>> {
     use std::process::Command;
 
     let mut attempts = Vec::new();
-    for (binary, args) in WAYLAND_TYPERS {
+    for (binary, args) in resolved {
         // `--` stops a leading dash being read as a flag
-        match Command::new(binary).args(args).arg(text).output() {
+        match Command::new(binary).args(*args).arg(text).output() {
             Ok(output) if output.status.success() => return Ok(()),
             Ok(output) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 attempts.push(format!(
-                    "{binary} exited with {}: {}",
+                    "{} exited with {}: {}",
+                    binary.display(),
                     output.status,
                     stderr.trim()
                 ));
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                attempts.push(format!("{binary} is not installed"));
-            }
-            Err(e) => attempts.push(format!("{binary} failed to start: {e}")),
+            Err(e) => attempts.push(format!("{} failed to start: {e}", binary.display())),
         }
     }
 
-    // Never Ok here: the caller plays the ready cue on Ok.
+    if attempts.is_empty() {
+        return Err(no_typer_error());
+    }
     Err(format!(
         "could not type into the focused window on wayland ({}); \
-         install wtype or ydotool. the transcription is still in `banshee history`",
+         install 'wtype' (or 'ydotool'). the transcription is still in `banshee history`",
         attempts.join("; ")
     )
     .into())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn type_text_wayland(text: &str) -> Result<(), Box<dyn Error>> {
+    let path = crate::connect::resolved_path();
+    type_with(&resolve_wayland_typers(&path), text)
 }
 
 // Stage the text, then restore the old clipboard. Two impls: macOS and Windows
@@ -163,6 +201,7 @@ fn stage(mut clipboard: Clipboard, text: &str, old: Option<String>) -> Result<()
 #[cfg(all(test, unix, not(target_os = "macos")))]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
 
     // Without `--`, wtype reads a leading dash as a flag and drops the text.
     #[test]
@@ -177,20 +216,92 @@ mod tests {
     }
 
     #[test]
-    fn failing_to_type_is_reported_as_an_error() {
-        // A scrubbed PATH resolves no typer, so this hits the both-missing path
-        let path = std::env::var_os("PATH");
-        // SAFETY: single-threaded test, restored before returning
-        unsafe { std::env::set_var("PATH", "") };
-        let result = type_text_wayland("hello");
-        if let Some(path) = path {
-            unsafe { std::env::set_var("PATH", path) };
-        }
-
-        let error = result.expect_err("missing typers must not report success");
-        let message = error.to_string();
+    fn no_typer_installed_is_reported_with_both_tool_names() {
+        // The resolver reads the login shell's PATH, not this process's, so
+        // scrubbing an env var here would prove nothing.
+        let message = no_typer_error().to_string();
         assert!(message.contains("wtype"), "unhelpful error: {message}");
         assert!(message.contains("ydotool"), "unhelpful error: {message}");
+    }
+
+    #[test]
+    fn resolve_wayland_typer_finds_nothing_on_an_empty_path() {
+        assert!(resolve_wayland_typer(OsStr::new("")).is_none());
+    }
+
+    #[test]
+    fn resolve_wayland_typer_returns_the_absolute_path_and_its_args() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("banshee-typer-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let wtype = dir.join("wtype");
+        std::fs::write(&wtype, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&wtype, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let found = resolve_wayland_typer(dir.as_os_str());
+
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let (binary, args) = found.expect("a directory holding wtype must resolve it");
+        assert_eq!(binary, wtype);
+        assert_eq!(args, &["--"]);
+    }
+
+    // A fresh directory per script, so concurrent tests never share a path.
+    fn write_script(name: &str, exit_code: u8, stderr: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!(
+            "banshee-typer-{}-{name}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join(name);
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\necho '{stderr}' >&2\nexit {exit_code}\n"),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        script
+    }
+
+    #[test]
+    fn a_typer_that_fails_at_runtime_falls_through_to_the_next() {
+        let first = write_script("first", 1, "no virtual keyboard protocol");
+        let second = write_script("second", 0, "");
+
+        let resolved = [(first.clone(), WAYLAND_TYPERS[0].1), (second.clone(), WAYLAND_TYPERS[1].1)];
+        let result = type_with(&resolved, "hello");
+
+        let _ = std::fs::remove_dir_all(first.parent().unwrap());
+        let _ = std::fs::remove_dir_all(second.parent().unwrap());
+
+        assert!(
+            result.is_ok(),
+            "a working second typer must recover from a failing first one: {result:?}"
+        );
+    }
+
+    #[test]
+    fn an_error_when_every_typer_fails_names_every_attempt() {
+        let first = write_script("alpha", 1, "boom-alpha");
+        let second = write_script("beta", 1, "boom-beta");
+
+        let resolved = [(first.clone(), WAYLAND_TYPERS[0].1), (second.clone(), WAYLAND_TYPERS[1].1)];
+        let message = type_with(&resolved, "hello")
+            .expect_err("two failing typers must not report success")
+            .to_string();
+
+        let _ = std::fs::remove_dir_all(first.parent().unwrap());
+        let _ = std::fs::remove_dir_all(second.parent().unwrap());
+
+        assert!(
+            message.contains("boom-alpha") && message.contains("boom-beta"),
+            "every attempt must be named: {message}"
+        );
     }
 }
 

--- a/bansheed/src/permissions.rs
+++ b/bansheed/src/permissions.rs
@@ -1,10 +1,8 @@
 // A TCC grant applies only to processes started after it lands, so the daemon
 // has to restart to pick one up. No equivalent outside macOS.
 
-use banshee_common::Blocker;
-#[cfg(target_os = "macos")]
-use banshee_common::BlockerKind;
 use banshee_common::error::BansheeError;
+use banshee_common::{Blocker, BlockerKind};
 
 #[cfg(target_os = "macos")]
 #[derive(Clone, Copy)]
@@ -182,9 +180,48 @@ fn blocker(grant: &Grant) -> Blocker {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+// X11 types through enigo directly, so only a Wayland session needs a typer.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub fn blockers() -> Vec<Blocker> {
+    let path = crate::connect::resolved_path();
+    blockers_for(
+        crate::dictation::is_wayland(),
+        crate::dictation::resolve_wayland_typer(&path).is_some(),
+    )
+}
+
+// Neither macOS nor a Wayland-capable unix: no client of this build ever sees
+// a typer blocker.
+#[cfg(not(any(target_os = "macos", unix)))]
 pub fn blockers() -> Vec<Blocker> {
     Vec::new()
+}
+
+/// Split from the live reads, which answer only on the machine and session
+/// this runs in.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn blockers_for(wayland: bool, typer_resolved: bool) -> Vec<Blocker> {
+    if wayland && !typer_resolved {
+        vec![wayland_typer_blocker()]
+    } else {
+        Vec::new()
+    }
+}
+
+// No client reads `command` on a pipeline blocker, so the fix carries the
+// tool names in prose instead of a distribution-specific install line.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn wayland_typer_blocker() -> Blocker {
+    Blocker {
+        role: None,
+        remedy: None,
+        kind: BlockerKind::Pipeline,
+        id: "wayland_typer".to_string(),
+        name: "Typing tool".to_string(),
+        consequence: "dictation cannot type anywhere".to_string(),
+        fix: "install 'wtype' (or 'ydotool')".to_string(),
+        command: None,
+    }
 }
 
 /// States what macOS asks for and checks nothing. It cannot read the grant (see
@@ -285,5 +322,34 @@ mod tests {
             "the fix is a settings path, not a command: {}",
             blocker.fix
         );
+    }
+}
+
+#[cfg(all(test, unix, not(target_os = "macos")))]
+mod wayland_typer_tests {
+    use super::*;
+
+    #[test]
+    fn wayland_with_no_typer_gets_one_pipeline_blocker() {
+        let found = blockers_for(true, false);
+        assert_eq!(found.len(), 1, "a missing typer on wayland must block");
+        assert_eq!(found[0].kind, BlockerKind::Pipeline);
+        assert_eq!(found[0].id, "wayland_typer");
+        assert_eq!(found[0].command, None);
+        assert!(
+            found[0].fix.contains("wtype") && found[0].fix.contains("ydotool"),
+            "the fix must name both tools: {}",
+            found[0].fix
+        );
+    }
+
+    #[test]
+    fn wayland_with_a_resolved_typer_has_no_blocker() {
+        assert!(blockers_for(true, true).is_empty());
+    }
+
+    #[test]
+    fn x11_never_blocks_on_a_typer() {
+        assert!(blockers_for(false, false).is_empty());
     }
 }

--- a/bansheed/src/service.rs
+++ b/bansheed/src/service.rs
@@ -183,57 +183,96 @@ mod systemd {
     use std::process::Command;
 
     use banshee_common::error::BansheeError;
+    use banshee_common::utils::{DAEMON_AGENT, TRAY_AGENT, sibling, systemd_unit};
 
-    const UNIT: &str = banshee_common::utils::DAEMON_UNIT;
+    fn label(agent: Agent) -> &'static str {
+        match agent {
+            Agent::Daemon => DAEMON_AGENT,
+            Agent::Tray => TRAY_AGENT,
+        }
+    }
+
+    fn unit_name(agent: Agent) -> &'static str {
+        systemd_unit(label(agent)).expect("every agent names its own unit")
+    }
+
+    fn unit_path(agent: Agent) -> Option<PathBuf> {
+        Some(
+            dirs::config_dir()?
+                .join("systemd/user")
+                .join(unit_name(agent)),
+        )
+    }
 
     pub fn service_file_path() -> Option<PathBuf> {
-        Some(dirs::config_dir()?.join("systemd/user").join(UNIT))
+        unit_path(Agent::Daemon)
+    }
+
+    /// The command this binary runs as, quoted the way a shell needs.
+    fn exec_start(agent: Agent) -> Result<String, BansheeError> {
+        let binary = std::env::current_exe()?;
+        Ok(match agent {
+            Agent::Daemon => format!("\"{}\" serve", binary.display()),
+            Agent::Tray => format!("\"{}\"", sibling(&binary, "banshee-tray")?.display()),
+        })
+    }
+
+    /// The daemon opens the microphone and is useful with no desktop, so it
+    /// waits on pipewire and wants the boot target. The tray has no bar to
+    /// sit in without a session, so it waits on the session instead, and
+    /// stops when the session does.
+    fn content(agent: Agent, exec_start: &str) -> String {
+        match agent {
+            Agent::Daemon => format!(
+                r#"[Unit]
+Description=Banshee voice daemon
+After=pipewire.service
+
+[Service]
+ExecStart={exec_start}
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+"#
+            ),
+            Agent::Tray => format!(
+                r#"[Unit]
+Description=Banshee menu bar icon
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+ExecStart={exec_start}
+Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target
+"#
+            ),
+        }
     }
 
     pub fn install(agent: Agent) -> Result<String, BansheeError> {
-        if agent != Agent::Daemon {
-            return Err(BansheeError::Other(
-                "the menu bar icon is macOS only; here use: banshee watch --waybar".into(),
-            ));
-        }
-        let unit = service_file_path()
-            .ok_or_else(|| BansheeError::Other("config dir not found".into()))?;
-        let binary = std::env::current_exe()?;
+        let unit =
+            unit_path(agent).ok_or_else(|| BansheeError::Other("config dir not found".into()))?;
         if let Some(dir) = unit.parent() {
             std::fs::create_dir_all(dir)?;
         }
 
         // No log paths: systemd captures stdout/stderr into the journal.
-        // After=pipewire.service so the mic exists before the daemon opens it
-        let content = format!(
-            r#"[Unit]
-Description=Banshee voice daemon
-After=pipewire.service
-
-[Service]
-ExecStart="{}" serve
-Restart=on-failure
-
-[Install]
-WantedBy=default.target
-"#,
-            binary.display()
-        );
-
-        std::fs::write(&unit, content)?;
+        std::fs::write(&unit, content(agent, &exec_start(agent)?))?;
         systemctl(&["daemon-reload"])?;
-        systemctl(&["enable", UNIT])?;
+        systemctl(&["enable", unit_name(agent)])?;
         // restart, not start: a reinstall must hand over to the new binary
-        systemctl(&["restart", UNIT])?;
-        Ok("journalctl --user -u banshee -f".to_string())
+        systemctl(&["restart", unit_name(agent)])?;
+        let service = unit_name(agent).trim_end_matches(".service");
+        Ok(format!("journalctl --user -u {service} -f"))
     }
 
     pub fn uninstall(agent: Agent) -> Result<bool, BansheeError> {
-        if agent != Agent::Daemon {
-            return Ok(false);
-        }
-        let _ = systemctl(&["disable", "--now", UNIT]);
-        match service_file_path() {
+        let _ = systemctl(&["disable", "--now", unit_name(agent)]);
+        match unit_path(agent) {
             Some(unit) if unit.exists() => {
                 std::fs::remove_file(&unit)?;
                 let _ = systemctl(&["daemon-reload"]);

--- a/bansheed/src/status.rs
+++ b/bansheed/src/status.rs
@@ -87,15 +87,14 @@ pub async fn run(config: Result<Config, BansheeError>) -> bool {
     // Same cfg as `is_wayland`, so every unix target that loses it explains why.
     #[cfg(all(unix, not(target_os = "macos")))]
     if crate::dictation::is_wayland() {
-        // The table dictation actually runs, so the checklist cannot name a stale tool
+        // The same search dictation runs, so the checklist cannot name a stale tool
         let path = crate::connect::resolved_path();
-        let typer = crate::dictation::WAYLAND_TYPERS
-            .into_iter()
-            .map(|(binary, _)| binary)
-            .find(|binary| resolve(binary, &path).is_some());
-        match typer {
-            Some(tool) => {
-                pass(&format!("wayland session: dictation types via {tool}"));
+        match crate::dictation::resolve_wayland_typer(&path) {
+            Some((binary, _)) => {
+                pass(&format!(
+                    "wayland session: typing tool found at {}",
+                    binary.display()
+                ));
             }
             None => note(
                 "wayland session: install 'wtype' (or 'ydotool') or dictation cannot type anywhere",
@@ -144,22 +143,26 @@ fn check_espeak() {
     }
 }
 
-fn espeak_install_hint() -> &'static str {
+fn espeak_install_hint() -> String {
+    package_install_hint("espeak-ng")
+}
+
+pub(crate) fn package_install_hint(package: &str) -> String {
     if cfg!(target_os = "macos") {
-        return "brew install espeak-ng";
+        return format!("brew install {package}");
     }
-    for (mgr, cmd) in [
-        ("apt", "sudo apt install espeak-ng"),
-        ("dnf", "sudo dnf install espeak-ng"),
-        ("pacman", "sudo pacman -S espeak-ng"),
-        ("zypper", "sudo zypper install espeak-ng"),
-        ("apk", "sudo apk add espeak-ng"),
+    for (mgr, verb) in [
+        ("apt", "install"),
+        ("dnf", "install"),
+        ("pacman", "-S"),
+        ("zypper", "install"),
+        ("apk", "add"),
     ] {
         if runs(mgr) {
-            return cmd;
+            return format!("sudo {mgr} {verb} {package}");
         }
     }
-    "your package manager's espeak-ng package"
+    format!("your package manager's {package} package")
 }
 
 fn runs(bin: &str) -> bool {

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -6,8 +6,10 @@ hotkey, and the Waybar module.
 
 ## Building the desktop window
 
-The window is a Tauri app. It needs WebKitGTK, GTK 3 and Node 22. The daemon
-and the CLI need none of these.
+The window is a Tauri app. It needs WebKitGTK, GTK 3 and Node 22. The tray
+needs GTK 3. The daemon and the CLI need none of them to run. A build from
+source still needs the GTK 3 headers, because one crate holds the daemon, the
+CLI and the tray.
 
 ```bash
 # Arch
@@ -39,7 +41,7 @@ The install points `banshee-app` at `target/release`, so a `cargo clean` or a
 moved clone breaks the window's daemon control. Run `make install-window`
 again to put it back.
 
-There is no tray icon here yet. `banshee-tray` still exits on Linux.
+`banshee tray` puts the mark in any bar that hosts StatusNotifierItem.
 `banshee watch --waybar` reports the state instead.
 
 ## The hotkey on Wayland


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Linux system tray icon, including support for starting it automatically as a service.
  - Tray icons now remain identifiable across restarts and work with supported desktop bars.
  - Added a visible blocker when Wayland has no compatible typing tool installed.
  - Dictation now uses the typing tool reported by status checks and can fall back to alternatives.

- **Documentation**
  - Updated Linux installation, building, and changelog guidance for tray support and Wayland requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->