### PR TITLE
chore: release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-09-12
+
 ### Added
 
 - **The menu bar icon now runs on Linux.** `banshee tray` puts the mark in any
@@ -753,7 +755,9 @@ First public release. macOS only for now; Windows and Linux support is planned.
 - Configurable VAD threshold via `config.toml` and the `banshee.configure` RPC,
   reported back through `banshee status`.
 
-[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/yamanahlawat/banshee/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/yamanahlawat/banshee/compare/v0.12.2...v0.13.0
+[0.12.2]: https://github.com/yamanahlawat/banshee/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/yamanahlawat/banshee/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/yamanahlawat/banshee/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/yamanahlawat/banshee/compare/v0.11.0...v0.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "banshee"
-version = "0.13.0-rc.1"
+version = "0.13.0"
 dependencies = [
  "arboard",
  "audioadapter-buffers",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-app"
-version = "0.13.0-rc.1"
+version = "0.13.0"
 dependencies = [
  "banshee-common",
  "serde",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "banshee-common"
-version = "0.13.0-rc.1"
+version = "0.13.0"
 dependencies = [
  "dirs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bansheed", "banshee-common", "banshee-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0-rc.1"
+version = "0.13.0"
 edition = "2024"
 authors = ["Yaman Ahlawat"]
 license = "MIT OR Apache-2.0"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,10 @@ verify it on a real machine. `BACKLOG.md` holds what is missing or wrong today, 
   after showing the change. Antigravity, Claude Code, OpenCode and Pi are verified on a real
   install; Cursor and Codex wait for a report (#53, #54).
 - A microphone that disappears no longer stops dictation (#47).
+- The desktop window and the menu bar icon run on Linux. `make install-window` builds both
+  from a source clone, and the icon sits in any bar that hosts StatusNotifierItem. The
+  blockers band names a missing Wayland typer. On Wayland the compositor holds the hotkey,
+  and the window says so instead of naming a key nothing binds.
 
 ## Next, maintainer
 
@@ -40,12 +44,11 @@ verify it on a real machine. `BACKLOG.md` holds what is missing or wrong today, 
    3. Remote speech. The same OpenAI-compatible shape first, ElevenLabs second for its
       expressive controls. After transcription because it touches the output sink path,
       which the output-sinks item below records as fragile.
-2. The window on Linux, as an AppImage and an AUR package, built by the bundle workflow with
-   GTK and WebKit installed. The blockers band grows rows for the typers and the daemon's
-   `PATH`, and the launcher stands in for the tray. After the keys, because the CLI loop
-   already covers Linux: dictation and spoken status with Claude Code are verified on Omarchy,
-   and `banshee watch --waybar` covers the live loop. It also gives the WebDriver acceptance
-   layer its first host: `tauri-driver` runs on Linux, not on macOS.
+2. Linux packaging: an AppImage and an AUR package, built by the bundle workflow with GTK and
+   WebKit installed. The window and the tray already run there, but only from a source clone,
+   which asks a user for a Rust toolchain and Node. The daemon's `PATH` still wants a blockers
+   row. It also gives the WebDriver acceptance layer its first host: `tauri-driver` runs on
+   Linux, not on macOS.
 3. Output sinks that survive a device change (the cue and Kokoro sinks still open once).
    Measure whether spoken status dies with the earcons before designing.
 4. Notarisation with an Apple Developer ID, so the bundle opens with no dialog. Last, because

--- a/bansheed/Cargo.toml
+++ b/bansheed/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 arboard = "3.6.1"
 audioadapter-buffers = "3.0.0"
-banshee-common = { version = "0.13.0-rc.1", path = "../banshee-common" }
+banshee-common = { version = "0.13.0", path = "../banshee-common" }
 chrono = "0.4"
 clap = { version = "4.6.1", features = ["derive"] }
 cpal = "0.17.3"


### PR DESCRIPTION
Cuts 0.13.0, the release that puts the window and the menu bar icon on Linux.

## what it does

- Dates the `[0.13.0]` changelog section and opens a fresh `[Unreleased]`.
- Moves the workspace to `0.13.0` from the `0.13.0-rc.1` the candidate carried.
- Moves the Linux window and tray to Landed on the roadmap. What remains there is packaging: the AppImage and the AUR package. Today Linux needs a source clone and `make install-window`.
- Adds the `[0.12.2]` changelog link reference, which the last release left out.

## testing

`v0.13.0-rc.1` built every target green, including both Linux ones. The shipped `banshee-tray` from that tarball links `libgtk-3.so.0`, which is what `libgtk-3-dev` in `dist-workspace.toml` was added for.

`dist plan --tag=v0.13.0` exits 0, reports `prerelease: false`, and resolves `libgtk-3-dev` on both Linux targets.

## what remains

The `custom-app-bundle` job was skipped for the prerelease, so the macOS bundle step runs for the first time on this tag.