### PR TITLE
fix: the cask guards with preflight_steps, which homebrew does not deprecate

### DIFF
--- a/packaging/banshee.cask.rb
+++ b/packaging/banshee.cask.rb
@@ -7,8 +7,8 @@ cask "banshee" do
   desc "Offline voice for coding agents, and system-wide dictation"
   homepage "https://github.com/yamanahlawat/banshee"
 
-  depends_on macos: :ventura
   depends_on arch: :arm64
+  depends_on macos: :ventura
 
   app "Banshee.app"
   binary "#{appdir}/Banshee.app/Contents/MacOS/banshee"
@@ -16,12 +16,20 @@ cask "banshee" do
 
   # The formula is the same daemon without the window, and two copies fight for one socket;
   # the shim formula is an old one still in the tap. Casks can conflict only with casks.
-  preflight do
-    %w[banshee banshee-mcp-shim].each do |formula|
-      next unless (HOMEBREW_PREFIX/"Cellar"/formula).directory?
-
-      raise CaskError,
-            "the #{formula} formula is installed; run `brew uninstall #{formula}` first, then install the cask"
+  preflight_steps do
+    if_path_exists "Cellar/banshee", base: :homebrew_prefix do
+      run "/bin/sh", args: [
+        "-c",
+        "echo 'the banshee formula is installed; run `brew uninstall banshee` first, " \
+        "then install the cask' >&2; exit 1",
+      ]
+    end
+    if_path_exists "Cellar/banshee-mcp-shim", base: :homebrew_prefix do
+      run "/bin/sh", args: [
+        "-c",
+        "echo 'the banshee-mcp-shim formula is installed; run `brew uninstall banshee-mcp-shim` first, " \
+        "then install the cask' >&2; exit 1",
+      ]
     end
   end
 


### PR DESCRIPTION
`brew upgrade` prints a deprecation warning for the banshee cask on every run, and `brew style` now fails the file. The release workflow runs `brew style` on the rendered cask, so the next release breaks at the bundle step once the runners carry a newer Homebrew.

## what it does

- Replaces the `preflight` block with `preflight_steps`. The guard still refuses the cask while the `banshee` or `banshee-mcp-shim` formula is installed.
- Puts `depends_on arch:` before `depends_on macos:`, which `Cask/StanzaOrder` wants.

## decisions worth a look

The guard stays rather than becoming `conflicts_with`. `Cask::DSL::ConflictsWith::VALID_KEYS` is `[:cask]`, so a cask still cannot declare a conflict with a formula. The comment above the stanza already says this and remains true.

The two formulas are written out rather than looped. `Cask/InstallSteps` rejects anything but DSL calls inside the block, so `%w[...].each` is an offense.

The message now comes from a failing `/bin/sh` rather than `raise CaskError`, because the new DSL has no raise step. The text is unchanged.

## testing

Rendered the template the way `app-bundle.yml` does, with the 0.13.0 version and sha, then ran `brew style` on it: no offenses. Before the change the same file gave 3.

Loaded the rendered cask in the real tap: the deprecation warning is gone and `brew info --cask banshee` still reports `arm64` and `macOS >= 13`. The tap was restored afterwards.

## what remains

The tap's own `Casks/banshee.rb` is regenerated only at release, so it keeps warning until then. It is being patched by hand with this same change.